### PR TITLE
[Feature] Focus on `TensorDictModule` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,6 @@ jobs:
     - name: Run checks
       run: |
         just checks
-    - name: Download assets
-      run: |
-        just test-assets
     - name: Run tests
       run: |
         just tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: check-added-large-files
         args: ['--maxkb=1024']
@@ -12,8 +12,8 @@ repos:
     -   id: trailing-whitespace
     -   id: check-docstring-first
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.9.1
+  rev: v0.12.9
   hooks:
-    - id: ruff
+    - id: ruff-check
       args: [ --fix ]
     - id: ruff-format

--- a/Justfile
+++ b/Justfile
@@ -5,9 +5,6 @@ install:
 checks:
 	uv run pre-commit run --all-files
 
-test-assets:
-	@echo "No test assets to resolve"
-
 tests:
 	uv run pytest tests --cov=src --cov-report=term-missing --cov-fail-under=50 -s -v
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
-# tdhook 🔍
+<img src="https://raw.githubusercontent.com/Xmaster6y/tdhook/refs/heads/main/docs/source/_static/images/tdhook-logo.png" alt="logo" width="200"/>
+
+# tdhook 🤖🪝
 
 [![Documentation](https://img.shields.io/badge/Documentation-blue.svg)](https://tdhook.readthedocs.io)
+[![tdhook](https://img.shields.io/pypi/v/tdhook?color=purple)](https://pypi.org/project/tdhook/)
 [![license](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://github.com/Xmaster6y/tdhook/blob/main/LICENSE)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![python versions](https://img.shields.io/badge/python-3.11%20|%203.12-blue)](https://www.python.org/downloads/)
+[![python versions](https://img.shields.io/pypi/pyversions/tdhook.svg)](https://www.python.org/downloads/)
+
+[![codecov](https://codecov.io/gh/Xmaster6y/tdhook/graph/badge.svg?token=JKJAWB451A)](https://codecov.io/gh/Xmaster6y/tdhook)
 ![ci](https://github.com/Xmaster6y/tdhook/actions/workflows/ci.yml/badge.svg)
 ![publish](https://github.com/Xmaster6y/tdhook/actions/workflows/publish.yml/badge.svg)
+[![docs](https://readthedocs.org/projects/tdhook/badge/?version=latest)](https://tdhook.readthedocs.io/en/latest/?badge=latest)
 
 Interpretability with `tensordict` and `torch` hooks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ scripts = [
     "captum>=0.8.0",
     "lczerolens",
     "scikit-learn>=1.7.1",
+    "torchrl>=0.9.2",
+    "gymnasium[mujoco]>=1.2.0",
 ]
 notebooks = [
     "ipykernel>=6.29.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,8 @@ scripts = [
     "transformer-lens>=2.15.4",
     "zennit>=0.5.1",
     "captum>=0.8.0",
+    "lczerolens",
+    "scikit-learn>=1.7.1",
 ]
 notebooks = [
     "ipykernel>=6.29.5",
@@ -72,6 +74,9 @@ build-backend = "setuptools.build_meta"
 
 [tool.uv]
 default-groups = ["dev"]
+
+[tool.uv.sources]
+lczerolens = { git = "https://github.com/Xmaster6y/lczerolens", branch = "chores" }
 
 [tool.ruff]
 line-length = 119

--- a/scripts/bench/check_accurate.py
+++ b/scripts/bench/check_accurate.py
@@ -21,11 +21,16 @@ TASKS = {
 }
 
 
-def main():
+def main(args):
     """Run all benchmarks."""
     logger.info("Checking if tasks are accurate...")
 
-    for task_name, scripts in TASKS.items():
+    # Filter tasks if specific ones are requested
+    tasks_to_run = TASKS
+    if args.tasks:
+        tasks_to_run = {k: v for k, v in TASKS.items() if k in args.tasks}
+
+    for task_name, scripts in tasks_to_run.items():
         all_outs = []
         for script in scripts:
             out = import_module(f"scripts.bench.tasks.{task_name}._{script}").main()
@@ -38,5 +43,17 @@ def main():
     logger.success("All tasks are accurate")
 
 
+def parse_args():
+    """Parse command line arguments."""
+    import argparse
+
+    parser = argparse.ArgumentParser("check-accurate")
+    parser.add_argument(
+        "--tasks", nargs="+", choices=list(TASKS.keys()), help="Specific tasks to check (default: all)"
+    )
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    main(args)

--- a/scripts/bench/plot_bundle.py
+++ b/scripts/bench/plot_bundle.py
@@ -73,12 +73,12 @@ def reset_environment():
     return True
 
 
-def main():
+def main(args):
     """Main function to measure bundle sizes and create plot."""
     logger.info("Starting bundle size measurement...")
 
     # Packages to test
-    packages = ["tdhook", "nnsight", "transformer_lens", "captum", "zennit"]
+    packages = args.packages
 
     # Store results
     results = {}
@@ -112,12 +112,12 @@ def main():
 
     # Create plot
     if results and base_size is not None:
-        create_plot(results, base_size)
+        create_plot(results, base_size, args.output_dir)
     else:
         logger.error("No results to plot")
 
 
-def create_plot(results, base_size):
+def create_plot(results, base_size, output_dir):
     """Create a bar chart of the results."""
     # Sort packages by size in increasing order
     sorted_packages = sorted(results.keys(), key=lambda pkg: results[pkg]["size"])
@@ -160,7 +160,7 @@ def create_plot(results, base_size):
     plt.tight_layout()
 
     # Save the plot
-    output_path = Path("results/bench/bundle/bundle_sizes.png")
+    output_path = Path(output_dir) / "bundle_sizes.png"
     output_path.parent.mkdir(exist_ok=True, parents=True)
     plt.savefig(output_path, dpi=300, bbox_inches="tight")
     logger.info(f"Plot saved to {output_path}")
@@ -180,5 +180,21 @@ def create_plot(results, base_size):
             logger.info(f"{package}: {int(size)}M")
 
 
+def parse_args():
+    """Parse command line arguments."""
+    import argparse
+
+    parser = argparse.ArgumentParser("plot-bundle")
+    parser.add_argument(
+        "--packages",
+        nargs="+",
+        default=["tdhook", "nnsight", "transformer_lens", "captum", "zennit"],
+        help="Packages to test",
+    )
+    parser.add_argument("--output-dir", type=str, default="results/bench/bundle", help="Output directory for plots")
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    main(args)

--- a/scripts/bench/plot_stats.py
+++ b/scripts/bench/plot_stats.py
@@ -376,12 +376,12 @@ def print_summary(results: Dict, task: str = "mlp_intervene"):
                             )
 
 
-def main():
+def main(args):
     """Load results and create plots."""
     logger.info("Loading benchmark results...")
 
     # Load results
-    results_path = Path("./results/bench/results.json")
+    results_path = Path(args.input_file)
     if not results_path.exists():
         logger.error(f"Results file not found: {results_path}")
         return
@@ -398,11 +398,25 @@ def main():
     plot_run_memory_group(results)
 
     # Print summary
-    print_summary(results)
+    print_summary(results, args.task)
 
     logger.success("Plotting completed!")
-    logger.info("Plots saved to './results/bench/stats/'")
+    logger.info(f"Plots saved to '{args.output_dir}'")
+
+
+def parse_args():
+    """Parse command line arguments."""
+    import argparse
+
+    parser = argparse.ArgumentParser("plot-stats")
+    parser.add_argument(
+        "--input-file", type=str, default="./results/bench/results.json", help="Input results file path"
+    )
+    parser.add_argument("--output-dir", type=str, default="./results/bench/stats", help="Output directory for plots")
+    parser.add_argument("--task", type=str, default="mlp_intervene", help="Task to summarize in the output")
+    return parser.parse_args()
 
 
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    main(args)

--- a/scripts/bench/tasks/_test.py
+++ b/scripts/bench/tasks/_test.py
@@ -34,15 +34,7 @@ def prepare(
     return model, input_data
 
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--batch_size", type=int, default=1024 * 1024)
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-
-    args = parser.parse_args()
-
+def main(args: argparse.Namespace):
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -65,5 +57,15 @@ def main():
     logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("test-task")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--batch_size", type=int, default=1024 * 1024)
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    main(args)

--- a/scripts/bench/tasks/gpt2_cache/_nnsight.py
+++ b/scripts/bench/tasks/gpt2_cache/_nnsight.py
@@ -43,17 +43,7 @@ def run(
     return logits, {k: v for k, v in activations.items() if v.node.executed}
 
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--model_size", type=str, default="gpt2")
-    parser.add_argument("--batch_size", type=int, default=10)
-    parser.add_argument("--variation", type=str, default="specific")
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-
-    args = parser.parse_args()
-
+def main(args: argparse.Namespace):
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -83,5 +73,17 @@ def main():
         logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("gpt2-cache-nnsight")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--model_size", type=str, default="gpt2")
+    parser.add_argument("--batch_size", type=int, default=10)
+    parser.add_argument("--variation", type=str, default="specific")
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    main(args)

--- a/scripts/bench/tasks/gpt2_cache/_tdhook.py
+++ b/scripts/bench/tasks/gpt2_cache/_tdhook.py
@@ -50,17 +50,7 @@ def run(
     return shuttle["output", "logits"], context.cache
 
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--model_size", type=str, default="gpt2")
-    parser.add_argument("--batch_size", type=int, default=10)
-    parser.add_argument("--variation", type=str, default="specific")
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-
-    args = parser.parse_args()
-
+def main(args: argparse.Namespace):
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -90,5 +80,17 @@ def main():
         logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("gpt2-cache-tdhook")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--model_size", type=str, default="gpt2")
+    parser.add_argument("--batch_size", type=int, default=10)
+    parser.add_argument("--variation", type=str, default="specific")
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    main(args)

--- a/scripts/bench/tasks/gpt2_cache/_tdhook.py
+++ b/scripts/bench/tasks/gpt2_cache/_tdhook.py
@@ -28,7 +28,7 @@ def prepare(
     sentences = ["Hello, world!"] * batch_size
     input_data = tokenizer(sentences, return_tensors="pt")
     input_data = {k: v.to("cuda" if use_cuda else "cpu") for k, v in input_data.items()}
-    return HookedModule(model, in_keys={k: k for k in input_data.keys()}, out_keys=["output"]), input_data
+    return HookedModule.from_module(model, in_keys={k: k for k in input_data.keys()}, out_keys=["output"]), input_data
 
 
 def run(
@@ -43,7 +43,7 @@ def run(
             return kwargs["output"][0]
         return kwargs["output"]
 
-    context = ActivationCaching(key_pattern="^(?!(module)?(\\.transformer)?$).*", callback=callback)
+    context = ActivationCaching(key_pattern="^(?!transformer$).*", callback=callback, relative=True)
     with context._hook_module(model):
         shuttle = TensorDict(input_data)
         model(shuttle)

--- a/scripts/bench/tasks/gpt2_cache/_transformer_lens.py
+++ b/scripts/bench/tasks/gpt2_cache/_transformer_lens.py
@@ -40,17 +40,7 @@ def run(
     return model.run_with_cache(**input_data)
 
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--model_size", type=str, default="gpt2")
-    parser.add_argument("--batch_size", type=int, default=10)
-    parser.add_argument("--variation", type=str, default="specific")
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-
-    args = parser.parse_args()
-
+def main(args: argparse.Namespace):
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -80,5 +70,17 @@ def main():
         logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("gpt2-cache-transformer-lens")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--model_size", type=str, default="gpt2")
+    parser.add_argument("--batch_size", type=int, default=10)
+    parser.add_argument("--variation", type=str, default="specific")
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    main(args)

--- a/scripts/bench/tasks/integrated_gradients/_captum.py
+++ b/scripts/bench/tasks/integrated_gradients/_captum.py
@@ -51,18 +51,7 @@ def run(
     return attributions, delta
 
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--width", type=int, default=10)
-    parser.add_argument("--height", type=int, default=10)
-    parser.add_argument("--batch_size", type=int, default=10)
-    parser.add_argument("--variation", type=str, default="multiply")
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-
-    args = parser.parse_args()
-
+def main(args: argparse.Namespace):
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -93,5 +82,18 @@ def main():
         logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("integrated-gradients-captum")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--width", type=int, default=10)
+    parser.add_argument("--height", type=int, default=10)
+    parser.add_argument("--batch_size", type=int, default=10)
+    parser.add_argument("--variation", type=str, default="multiply")
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    main(args)

--- a/scripts/bench/tasks/integrated_gradients/_captum_add.py
+++ b/scripts/bench/tasks/integrated_gradients/_captum_add.py
@@ -52,18 +52,7 @@ def run(
     return attributions1 + attributions2, delta1 + delta2
 
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--width", type=int, default=10)
-    parser.add_argument("--height", type=int, default=10)
-    parser.add_argument("--batch_size", type=int, default=10)
-    parser.add_argument("--variation", type=str, default="multiply")
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-
-    args = parser.parse_args()
-
+def main(args: argparse.Namespace):
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -94,5 +83,18 @@ def main():
         logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("integrated-gradients-captum-add")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--width", type=int, default=10)
+    parser.add_argument("--height", type=int, default=10)
+    parser.add_argument("--batch_size", type=int, default=10)
+    parser.add_argument("--variation", type=str, default="multiply")
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    main(args)

--- a/scripts/bench/tasks/integrated_gradients/_tdhook.py
+++ b/scripts/bench/tasks/integrated_gradients/_tdhook.py
@@ -62,18 +62,7 @@ def run(
         return output["input_attr"], output["convergence_delta"]
 
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--width", type=int, default=10)
-    parser.add_argument("--height", type=int, default=10)
-    parser.add_argument("--batch_size", type=int, default=10)
-    parser.add_argument("--variation", type=str, default="multiply")
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-
-    args = parser.parse_args()
-
+def main(args: argparse.Namespace):
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -104,5 +93,18 @@ def main():
         logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("integrated-gradients-tdhook")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--width", type=int, default=10)
+    parser.add_argument("--height", type=int, default=10)
+    parser.add_argument("--batch_size", type=int, default=10)
+    parser.add_argument("--variation", type=str, default="multiply")
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    main(args)

--- a/scripts/bench/tasks/lrp/_tdhook.py
+++ b/scripts/bench/tasks/lrp/_tdhook.py
@@ -55,18 +55,7 @@ def run(
         return output["input_attr"]
 
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--width", type=int, default=10)
-    parser.add_argument("--height", type=int, default=10)
-    parser.add_argument("--batch_size", type=int, default=10)
-    parser.add_argument("--variation", type=str, default="epsilon-plus")
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-
-    args = parser.parse_args()
-
+def main(args: argparse.Namespace):
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -97,5 +86,18 @@ def main():
         logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("lrp-tdhook")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--width", type=int, default=10)
+    parser.add_argument("--height", type=int, default=10)
+    parser.add_argument("--batch_size", type=int, default=10)
+    parser.add_argument("--variation", type=str, default="epsilon-plus")
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    main(args)

--- a/scripts/bench/tasks/lrp/_zennit.py
+++ b/scripts/bench/tasks/lrp/_zennit.py
@@ -53,18 +53,7 @@ def run(
         return input_data.grad
 
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--width", type=int, default=10)
-    parser.add_argument("--height", type=int, default=10)
-    parser.add_argument("--batch_size", type=int, default=10)
-    parser.add_argument("--variation", type=str, default="epsilon-plus")
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-
-    args = parser.parse_args()
-
+def main(args: argparse.Namespace):
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -95,5 +84,18 @@ def main():
         logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("lrp-zennit")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--width", type=int, default=10)
+    parser.add_argument("--height", type=int, default=10)
+    parser.add_argument("--batch_size", type=int, default=10)
+    parser.add_argument("--variation", type=str, default="epsilon-plus")
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    main(args)

--- a/scripts/bench/tasks/mlp_intervene/_nnsight.py
+++ b/scripts/bench/tasks/mlp_intervene/_nnsight.py
@@ -57,18 +57,7 @@ def run(
     return (state1, state2, state3)
 
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--width", type=int, default=10)
-    parser.add_argument("--height", type=int, default=10)
-    parser.add_argument("--batch_size", type=int, default=10)
-    parser.add_argument("--variation", type=int, default=10)
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-
-    args = parser.parse_args()
-
+def main(args: argparse.Namespace):
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -99,5 +88,18 @@ def main():
         logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("mlp-intervene-nnsight")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--width", type=int, default=10)
+    parser.add_argument("--height", type=int, default=10)
+    parser.add_argument("--batch_size", type=int, default=10)
+    parser.add_argument("--variation", type=int, default=10)
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    main(args)

--- a/scripts/bench/tasks/mlp_intervene/_tdhook.py
+++ b/scripts/bench/tasks/mlp_intervene/_tdhook.py
@@ -60,18 +60,7 @@ def run(
     return (state1.resolve(), state2.resolve(), state3.resolve())
 
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--width", type=int, default=10)
-    parser.add_argument("--height", type=int, default=10)
-    parser.add_argument("--batch_size", type=int, default=10)
-    parser.add_argument("--variation", type=int, default=10)
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-
-    args = parser.parse_args()
-
+def main(args: argparse.Namespace):
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -102,5 +91,18 @@ def main():
         logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("mlp-intervene-tdhook")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--width", type=int, default=10)
+    parser.add_argument("--height", type=int, default=10)
+    parser.add_argument("--batch_size", type=int, default=10)
+    parser.add_argument("--variation", type=int, default=10)
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    main(args)

--- a/scripts/bench/tasks/mlp_intervene/_tdhook.py
+++ b/scripts/bench/tasks/mlp_intervene/_tdhook.py
@@ -37,7 +37,7 @@ def prepare(
     """Prepare the model and input data."""
     model = MLP(height=height, width=width).to("cuda" if use_cuda else "cpu")
     input_data = torch.randn(batch_size, width).to("cuda" if use_cuda else "cpu")
-    return HookedModule(model, in_keys=["input"], out_keys=["output"]), input_data
+    return HookedModule.from_module(model, in_keys=["input"], out_keys=["output"]), input_data
 
 
 def run(

--- a/scripts/bench/test_measurement.py
+++ b/scripts/bench/test_measurement.py
@@ -26,28 +26,28 @@ def log_stats(stats: dict):
         logger.info(f"  {key}: {value}")
 
 
-def main():
+def main(args):
     """Test the measurement system."""
     logger.info("Testing measurement system...")
 
     measurer = Measurer()
 
-    for i in range(3):
+    for i in range(args.iterations):
         logger.info(f"Measuring `_base` ({i + 1})...")
         stats = measurer.measure_script("scripts/bench/tasks/_base.py", {})
         log_stats(stats)
 
-    for i in range(3):
+    for i in range(args.iterations):
         logger.info(f"Measuring `_test` ({i + 1})...")
         stats = measurer.measure_script("scripts/bench/tasks/_test.py", {})
         log_stats(stats)
 
-    for i in range(3):
+    for i in range(args.iterations):
         logger.info(f"Measuring `mlp_intervene._nnsight` ({i + 1})...")
         stats = measurer.measure_script("scripts/bench/tasks/mlp_intervene/_nnsight.py", {})
         log_stats(stats)
 
-    for i in range(3):
+    for i in range(args.iterations):
         logger.info(f"Measuring `mlp_intervene._tdhook` ({i + 1})...")
         stats = measurer.measure_script("scripts/bench/tasks/mlp_intervene/_tdhook.py", {})
         log_stats(stats)
@@ -55,5 +55,15 @@ def main():
     logger.success("Measurement test completed!")
 
 
+def parse_args():
+    """Parse command line arguments."""
+    import argparse
+
+    parser = argparse.ArgumentParser("test-measurement")
+    parser.add_argument("--iterations", type=int, default=3, help="Number of iterations to run for each test")
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    main(args)

--- a/scripts/bench/test_stats.py
+++ b/scripts/bench/test_stats.py
@@ -31,23 +31,28 @@ def run_default_task(task, script_name: str, measurer: Measurer):
     measurer.measure_script(script_name, default_parameters)
 
 
-def save_results(results: Dict):
+def save_results(results: Dict, output_file: str):
     """Save results to JSON file."""
-    results_dir = Path("./results/bench")
+    results_dir = Path(output_file).parent
     results_dir.mkdir(parents=True, exist_ok=True)
 
-    with open(results_dir / "test-results.json", "w") as f:
+    with open(output_file, "w") as f:
         json.dump(results, f, indent=2)
 
 
-def main():
+def main(args):
     """Run all benchmarks."""
     logger.info("Starting test stats...")
 
     measurer = Measurer()
     results = {}
 
-    for task_name, scripts in TASKS.items():
+    # Filter tasks if specific ones are requested
+    tasks_to_run = TASKS
+    if args.tasks:
+        tasks_to_run = {k: v for k, v in TASKS.items() if k in args.tasks}
+
+    for task_name, scripts in tasks_to_run.items():
         results[task_name] = {}
         for script in scripts:
             logger.info(f"Running task `{task_name}` with script `{script}`")
@@ -55,11 +60,24 @@ def main():
             task = import_module(f"scripts.bench.tasks.{task_name}")
             results[task_name][script] = run_default_task(task, script_name, measurer)
 
-    save_results(results)
+    save_results(results, args.output_file)
 
     logger.success("Test stats completed!")
-    logger.info("Results saved to './results/bench/test-results.json'")
+    logger.info(f"Results saved to '{args.output_file}'")
+
+
+def parse_args():
+    """Parse command line arguments."""
+    import argparse
+
+    parser = argparse.ArgumentParser("test-stats")
+    parser.add_argument("--tasks", nargs="+", choices=list(TASKS.keys()), help="Specific tasks to run (default: all)")
+    parser.add_argument(
+        "--output-file", type=str, default="./results/bench/test-results.json", help="Output file path for results"
+    )
+    return parser.parse_args()
 
 
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    main(args)

--- a/scripts/lczerolens/concept_probing.py
+++ b/scripts/lczerolens/concept_probing.py
@@ -1,0 +1,89 @@
+"""
+Script to probe concepts in a chess model.
+
+Run with:
+
+```
+uv run --group scripts -m scripts.lczerolens.concept_probing
+```
+"""
+
+import argparse
+from loguru import logger
+from tensordict import TensorDict
+import torch
+
+from datasets import load_dataset, Dataset
+from sklearn.linear_model import LogisticRegression
+from lczerolens import LczeroModel
+from lczerolens.concepts import Concept, HasThreat
+from lczerolens.data import BoardData
+
+from tdhook.acteng import ActivationCaching
+
+
+def train_logistic_regression(cache: TensorDict, labels: TensorDict):
+    """Train a logistic regression model."""
+    models = {}
+    for key, value in cache.items():
+        model = LogisticRegression()
+        model.fit(value.flatten(1), labels)
+        models[key] = model
+    return models
+
+
+def test_logistic_regression(cache: TensorDict, labels: TensorDict, models: dict, concept: Concept):
+    """Test a logistic regression model."""
+    metrics = {}
+    for key, value in cache.items():
+        model = models[key]
+        predictions = model.predict(value.flatten(1))
+        metrics[key] = concept.compute_metrics(predictions, labels)
+    return metrics
+
+
+def main(args: argparse.Namespace):
+    """Run all benchmarks."""
+    logger.info("Starting test stats...")
+
+    model = LczeroModel.from_path(args.model_path)
+    dataset = load_dataset("lczerolens/tcec-boards", split="train", streaming=True)
+    work_ds = dataset.shuffle(seed=42).take(1000)
+    work_ds = Dataset.from_generator(lambda: (yield from work_ds), features=work_ds.features)
+    work_ds = work_ds.train_test_split(test_size=0.2)
+    train_ds = work_ds["train"]
+    test_ds = work_ds["test"]
+
+    concept = HasThreat("K")
+    train_boards, train_labels = BoardData.concept_collate_fn(list(train_ds), concept)
+    test_boards, test_labels = BoardData.concept_collate_fn(list(test_ds), concept)
+
+    logger.info(f"Positive examples (train): {sum(train_labels)}")
+    logger.info(f"Positive examples (test): {sum(test_labels)}")
+
+    train_cache = TensorDict(batch_size=len(train_boards))
+    test_cache = TensorDict(batch_size=len(test_boards))
+
+    with ActivationCaching("block\d/conv2/relu", cache=train_cache).prepare(model) as hooked_module:
+        with torch.no_grad():
+            hooked_module(train_boards)
+
+    with ActivationCaching("block\d/conv2/relu", cache=test_cache).prepare(model) as hooked_module:
+        with torch.no_grad():
+            hooked_module(test_boards)
+
+    train_models = train_logistic_regression(train_cache, train_labels)
+    metrics = test_logistic_regression(test_cache, test_labels, train_models, concept)
+    for key, value in metrics.items():
+        logger.info(f"{key}: {value}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("concept-probing")
+    parser.add_argument("--model_path", type=str, default="results/lczerolens/maia-1900.onnx")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args)

--- a/scripts/xdrl/value_saliency.py
+++ b/scripts/xdrl/value_saliency.py
@@ -1,0 +1,91 @@
+"""
+Script to compute saliency maps for a value network using tdhook.
+
+Run with:
+
+```
+uv run --group scripts -m scripts.xdrl.value_saliency
+```
+"""
+
+import argparse
+from loguru import logger
+import torch
+from torch import nn
+from torchrl.envs import TransformedEnv, Compose, DoubleToFloat, StepCounter, DeviceCastTransform
+from torchrl.envs.libs.gym import GymEnv
+from torchrl.modules import ValueOperator
+
+from tdhook.attribution.gradient_attribution import Saliency
+from tdhook.module import get_best_device
+
+device = get_best_device()
+
+
+@torch.no_grad()
+def setup(args):
+    base_env = GymEnv(args.env_name)
+    env = TransformedEnv(
+        base_env,
+        Compose(
+            DoubleToFloat(),
+            StepCounter(),
+            DeviceCastTransform(device=device),
+        ),
+    )
+
+    value_net = nn.Sequential(
+        nn.LazyLinear(args.num_cells, device=device),
+        nn.Tanh(),
+        nn.LazyLinear(args.num_cells, device=device),
+        nn.Tanh(),
+        nn.LazyLinear(args.num_cells, device=device),
+        nn.Tanh(),
+        nn.LazyLinear(1, device=device),
+    )
+
+    value_head = ValueOperator(
+        module=value_net,
+        in_keys=["observation"],
+    )
+    return env, value_head
+
+
+def compute_saliency(value_head, batch):
+    """Compute saliency maps using tdhook."""
+    saliency_context = Saliency()
+
+    with saliency_context.prepare(value_head) as hooked_policy:
+        output = hooked_policy(batch)
+
+        saliency_maps = output.get(("attr", "observation"))
+
+        return saliency_maps
+
+
+def main(args):
+    """Run saliency map demo."""
+    logger.info("Starting value saliency demo...")
+
+    env, value_head = setup(args)
+
+    logger.info(f"Value created with {len(list(value_head.parameters()))} parameters")
+
+    batch = env.rollout(1000)
+
+    saliency_maps = compute_saliency(value_head, batch)
+
+    logger.info(f"Saliency maps computed: {saliency_maps.shape}")
+    logger.info(f"Mean absolute importance: {saliency_maps.abs().mean().item():.4f}")
+    logger.info("Demo completed!")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("value-saliency")
+    parser.add_argument("--env_name", type=str, default="InvertedDoublePendulum-v4")
+    parser.add_argument("--num_cells", type=int, default=32)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/scripts/xdrl/value_saliency.py
+++ b/scripts/xdrl/value_saliency.py
@@ -58,9 +58,7 @@ def compute_saliency(value_head, batch):
     with saliency_context.prepare(value_head) as hooked_policy:
         output = hooked_policy(batch)
 
-        saliency_maps = output.get(("attr", "observation"))
-
-        return saliency_maps
+        return output.get(("attr", "observation"))
 
 
 def main(args):

--- a/src/tdhook/_types.py
+++ b/src/tdhook/_types.py
@@ -1,0 +1,19 @@
+"""
+Various types.
+"""
+
+
+class UnraveledMeta(type):
+    def __instancecheck__(self, instance):
+        return isinstance(instance, str) or (
+            isinstance(instance, tuple) and len(instance) and all(isinstance(subkey, str) for subkey in instance)
+        )
+
+
+class UnraveledKey(metaclass=UnraveledMeta):
+    """Unraveled key.
+
+    Either a string or a tuple of strings.
+    """
+
+    pass

--- a/src/tdhook/acteng/activation_caching.py
+++ b/src/tdhook/acteng/activation_caching.py
@@ -20,7 +20,7 @@ class ActivationCaching(HookingContextFactory):
         callback: Optional[Callable] = None,
         directions: Optional[List[HookDirection]] = None,
     ):
-        self.cache = cache or TensorDict()
+        self._cache = TensorDict() if cache is None else cache
 
         self._key_pattern = key_pattern
         self._hook_manager = MultiHookManager(key_pattern, relative=relative)
@@ -39,7 +39,7 @@ class ActivationCaching(HookingContextFactory):
     def _hook_module(self, module: HookedModule) -> MultiHookHandle:
         def hook_factory(name: str, direction: HookDirection) -> Callable:
             nonlocal self
-            return HookFactory.make_caching_hook(name, self.cache, direction=direction, callback=self._callback)
+            return HookFactory.make_caching_hook(name, self._cache, direction=direction, callback=self._callback)
 
         handles = []
         for direction in self._directions:

--- a/src/tdhook/acteng/activation_caching.py
+++ b/src/tdhook/acteng/activation_caching.py
@@ -28,6 +28,10 @@ class ActivationCaching(HookingContextFactory):
         self._directions = directions or ["fwd"]
 
     @property
+    def cache(self) -> TensorDict:
+        return self._cache
+
+    @property
     def key_pattern(self) -> str:
         return self._key_pattern
 

--- a/src/tdhook/acteng/activation_caching.py
+++ b/src/tdhook/acteng/activation_caching.py
@@ -15,7 +15,7 @@ class ActivationCaching(HookingContextFactory):
     def __init__(
         self,
         key_pattern: str,
-        relative: bool = False,
+        relative: bool = True,
         cache: Optional[TensorDict] = None,
         callback: Optional[Callable] = None,
         directions: Optional[List[HookDirection]] = None,

--- a/src/tdhook/acteng/linear_probing.py
+++ b/src/tdhook/acteng/linear_probing.py
@@ -31,6 +31,10 @@ class LinearProbing(HookingContextFactory):
         self._directions = directions or ["fwd"]
 
     @property
+    def cache(self) -> TensorDict:
+        return self._cache
+
+    @property
     def key_pattern(self) -> str:
         return self._key_pattern
 

--- a/src/tdhook/acteng/linear_probing.py
+++ b/src/tdhook/acteng/linear_probing.py
@@ -12,6 +12,7 @@ from tdhook.hooks import MultiHookManager, HookFactory, HookDirection, MultiHook
 
 
 class LinearProbing(HookingContextFactory):
+    # TODO: refactor to use ActivationCaching and focus on minibatch training
     def __init__(
         self,
         key_pattern: str,
@@ -21,7 +22,7 @@ class LinearProbing(HookingContextFactory):
         preprocess: Optional[Callable] = None,
         directions: Optional[List[HookDirection]] = None,
     ):
-        self.cache = cache or TensorDict()
+        self._cache = TensorDict() if cache is None else cache
 
         self._key_pattern = key_pattern
         self._hook_manager = MultiHookManager(key_pattern, relative=relative)
@@ -53,7 +54,7 @@ class LinearProbing(HookingContextFactory):
                 def callback(**kwargs):
                     return probe(kwargs[DIRECTION_TO_RETURN[direction]])
 
-            return HookFactory.make_caching_hook(name, self.cache, direction=direction, callback=callback)
+            return HookFactory.make_caching_hook(name, self._cache, direction=direction, callback=callback)
 
         handles = []
         for direction in self._directions:

--- a/src/tdhook/acteng/linear_probing.py
+++ b/src/tdhook/acteng/linear_probing.py
@@ -16,7 +16,7 @@ class LinearProbing(HookingContextFactory):
         self,
         key_pattern: str,
         probe_factory: Callable[[str, str], Callable],
-        relative: bool = False,
+        relative: bool = True,
         cache: Optional[TensorDict] = None,
         preprocess: Optional[Callable] = None,
         directions: Optional[List[HookDirection]] = None,

--- a/src/tdhook/acteng/linear_probing.py
+++ b/src/tdhook/acteng/linear_probing.py
@@ -16,6 +16,7 @@ class LinearProbing(HookingContextFactory):
         self,
         key_pattern: str,
         probe_factory: Callable[[str, str], Callable],
+        relative: bool = False,
         cache: Optional[TensorDict] = None,
         preprocess: Optional[Callable] = None,
         directions: Optional[List[HookDirection]] = None,
@@ -23,7 +24,7 @@ class LinearProbing(HookingContextFactory):
         self.cache = cache or TensorDict()
 
         self._key_pattern = key_pattern
-        self._hook_manager = MultiHookManager(key_pattern)
+        self._hook_manager = MultiHookManager(key_pattern, relative=relative)
         self._probe_factory = probe_factory
         self._preprocess = preprocess
         self._directions = directions or ["fwd"]

--- a/src/tdhook/artifacts.py
+++ b/src/tdhook/artifacts.py
@@ -1,5 +1,6 @@
 """
 Artifacts
+TODO: Deprecate this module.
 """
 
 import torch

--- a/src/tdhook/attribution/gradient_attribution/common.py
+++ b/src/tdhook/attribution/gradient_attribution/common.py
@@ -40,6 +40,7 @@ class GradientAttribution(HookingContextFactory, metaclass=ABCMeta):
                 "module",
                 self._input_grad_hook,
                 direction="fwd_pre",
+                relative=False,
             )
         )
 
@@ -48,6 +49,7 @@ class GradientAttribution(HookingContextFactory, metaclass=ABCMeta):
                 "module",
                 self._output_backward_hook,
                 direction="fwd",
+                relative=False,
             )
         )
 
@@ -57,6 +59,7 @@ class GradientAttribution(HookingContextFactory, metaclass=ABCMeta):
                     "",
                     self._attr_multiply_hook,
                     direction="fwd",
+                    relative=False,
                 )
             )
 
@@ -117,6 +120,7 @@ class GradientAttributionWithBaseline(GradientAttribution):
                 "",
                 self._assert_batched_hook,
                 direction="fwd_pre",
+                relative=False,
             )
         )
 
@@ -125,6 +129,7 @@ class GradientAttributionWithBaseline(GradientAttribution):
                 "module",
                 self._reduce_baselines_hook,
                 direction="fwd_pre",
+                relative=False,
             )
         )
 
@@ -136,6 +141,7 @@ class GradientAttributionWithBaseline(GradientAttribution):
                     "module",
                     self._convergence_delta_placeholder_hook,
                     direction="fwd",
+                    relative=False,
                 )
             )
 
@@ -144,6 +150,7 @@ class GradientAttributionWithBaseline(GradientAttribution):
                     "",
                     self._compute_convergence_delta_hook,
                     direction="fwd",
+                    relative=False,
                 )
             )
 

--- a/src/tdhook/attribution/gradient_attribution/common.py
+++ b/src/tdhook/attribution/gradient_attribution/common.py
@@ -104,9 +104,9 @@ class GradientAttributionWithBaseline(GradientAttribution):
         self, prep_module: nn.Module, in_keys: List[str], out_keys: List[str], hooking_context: HookingContext
     ):
         hooked_module = super()._spawn_hooked_module(prep_module, in_keys, out_keys, hooking_context)
-        hooked_module.in_keys = in_keys + [f"{in_key}_baseline" for in_key in in_keys]
+        hooked_module.td_module.in_keys = in_keys + [f"{in_key}_baseline" for in_key in in_keys]
         if self._compute_convergence_delta:
-            hooked_module._out_keys = hooked_module._out_keys + ["convergence_delta"]
+            hooked_module.td_module._out_keys = hooked_module.td_module._out_keys + ["convergence_delta"]
         return hooked_module
 
     def _hook_module(self, module: HookedModule) -> MultiHookHandle:

--- a/src/tdhook/attribution/gradient_attribution/common.py
+++ b/src/tdhook/attribution/gradient_attribution/common.py
@@ -3,104 +3,110 @@ Gradient attribution
 """
 
 from abc import ABCMeta, abstractmethod
-from typing import Callable, Optional, Tuple, Dict, List
+from typing import Callable, Optional, Tuple, List
 
 import torch
-from tensordict.nn import TensorDictModule, TensorDictSequential
+from tensordict.nn import TensorDictModule, TensorDictSequential, TensorDictModuleBase
+from tensordict import TensorDict
 
 from tdhook.contexts import HookingContextFactory
-from tdhook.module import HookedModule
+from tdhook.module import HookedModule, FunctionModule
 from tdhook.hooks import MultiHookHandle
+from tdhook._types import UnraveledKey
 
 
 class GradientAttribution(HookingContextFactory, metaclass=ABCMeta):
     def __init__(
         self,
-        init_targets: Optional[
-            Callable[[Dict[str, torch.Tensor], Dict[str, torch.Tensor]], Dict[str, torch.Tensor]]
-        ] = None,
-        init_grads: Optional[
-            Callable[[Dict[str, torch.Tensor], Dict[str, torch.Tensor]], Dict[str, torch.Tensor]]
-        ] = None,
+        init_targets: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
+        init_grads: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
         multiply_by_inputs: bool = False,
-        additional_init_keys: Optional[List[str]] = None,
+        additional_init_keys: Optional[List[UnraveledKey]] = None,
     ):
         self._init_targets = init_targets
         self._init_grads = init_grads
         self._multiply_by_inputs = multiply_by_inputs
         self._additional_init_keys = additional_init_keys or []
 
-    def _prepare_module(self, module: TensorDictModule) -> TensorDictModule:
-        n_in_keys = len(module.in_keys)
-        attr_keys = [f"{in_key}_attr" for in_key in module.in_keys]
+    def _prepare_module(
+        self, module: TensorDictModuleBase, in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
+    ) -> TensorDictModuleBase:
+        n_in_keys = len(in_keys)
+        saved_keys = [("saved", in_key) for in_key in in_keys]
+        attr_keys = [("attr", in_key) for in_key in in_keys]
 
-        if set(self._additional_init_keys) & (set(module.in_keys) | set(module.out_keys)):
-            raise ValueError("Additional init keys must not be in the module's in_keys or out_keys")
+        if set(self._additional_init_keys) & (set(in_keys) | set(out_keys)):
+            raise ValueError("Additional init keys must not be in the in_keys or out_keys")
+        modules = []
 
-        modules = [module]
         modules.append(
             TensorDictModule(
-                lambda **tensors: self._attributor_fn(tensors, module.in_keys, module.out_keys),
-                in_keys={k: k for k in module.in_keys + module.out_keys + self._additional_init_keys},
-                out_keys=attr_keys,
+                self._register_inputs_fn,
+                in_keys=in_keys,
+                out_keys=saved_keys,
                 inplace=True,
-            )  # TODO: replace with custom module to pass TensorDict to _attributor_fn
+            )
+        )
+        modules.append(module)
+        modules.append(
+            FunctionModule(
+                lambda td: self._attributor_fn(td, saved_keys, out_keys),
+                in_keys=saved_keys + out_keys + self._additional_init_keys,
+                out_keys=attr_keys,
+            )
         )
         if self._multiply_by_inputs:
             modules.append(
                 TensorDictModule(
                     lambda *tensors: self._multiply_by_inputs_fn(tensors[:n_in_keys], tensors[n_in_keys:]),
-                    in_keys=module.in_keys + attr_keys,
+                    in_keys=saved_keys + attr_keys,
                     out_keys=attr_keys,
                     inplace=True,
                 )
             )
         return TensorDictSequential(*modules)
 
-    def _hook_module(self, module: HookedModule) -> MultiHookHandle:
-        handle = module.register_submodule_hook(
-            "td_module",
-            lambda *args: self._set_requires_grad_hook(*args, module.in_keys),
-            direction="fwd_pre",
-            relative=False,
-        )
-        return MultiHookHandle([handle])
-
-    def _set_requires_grad_hook(self, module, args, in_keys):  # TODO: needed with autograd?
-        for arg in args:
-            arg.requires_grad_(True)
+    def _register_inputs_fn(self, *inputs):  # TODO: needed with autograd?
+        return tuple(inp.requires_grad_(True) for inp in inputs)
 
     def _attributor_fn(
-        self, tensors: Dict[str, torch.Tensor], in_keys: List[str], out_keys: List[str]
-    ) -> Dict[str, torch.Tensor]:
-        outputs = {k: tensors[k] for k in out_keys}
-        additional_init_tensors = {k: tensors[k] for k in self._additional_init_keys}
+        self, td: TensorDict, saved_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
+    ) -> TensorDict:
+        outputs = td.select(*out_keys)
+        additional_init_tensors = td.select(*self._additional_init_keys)
 
         if self._init_targets is not None:
             targets = self._init_targets(outputs, additional_init_tensors)
+            if not isinstance(targets, TensorDict):
+                raise ValueError("init_targets function must return a TensorDict")
         else:
             targets = outputs
         if self._init_grads is not None:
             init_grads = self._init_grads(targets, additional_init_tensors)
+            if not isinstance(init_grads, TensorDict):
+                raise ValueError("init_grads function must return a TensorDict")
         else:
-            init_grads = {k: torch.ones_like(target) for k, target in targets.items()}
+            init_grads = torch.ones_like(targets)
 
-        if set(targets.keys()) != set(init_grads.keys()):
+        if set(targets.keys(True, True)) != set(init_grads.keys(True, True)):
             raise ValueError("Targets and init_grads must have the same keys")
+        for target_key, target in targets.items():
+            if target.grad_fn is None:
+                raise ValueError(f"Target {target_key} has no grad_fn")
 
-        tup_targets = tuple(targets[k] for k in targets.keys())
-        tup_init_grads = tuple(init_grads[k] for k in targets.keys())
-        tup_inputs = tuple(tensors[k] for k in in_keys)
+        inputs = td.select(*saved_keys)
 
-        return self._grad_attr(tup_targets, tup_inputs, tup_init_grads)
+        grads = self._grad_attr(targets, inputs, init_grads)
+        td["attr"] = grads["saved"]
+        return td
 
     @abstractmethod
     def _grad_attr(
         self,
-        targets: Tuple[torch.Tensor, ...],
-        inputs: Tuple[torch.Tensor, ...],
-        init_grads: Tuple[torch.Tensor, ...],
-    ) -> Tuple[torch.Tensor, ...]:
+        targets: TensorDict,
+        inputs: TensorDict,
+        init_grads: TensorDict,
+    ) -> TensorDict:
         pass
 
     @torch.no_grad()
@@ -113,37 +119,37 @@ class GradientAttributionWithBaseline(GradientAttribution):
         super().__init__(*args, **kwargs)
         self._compute_convergence_delta = compute_convergence_delta
 
-    def _prepare_module(self, module: TensorDictModule) -> TensorDictModule:
-        n_in_keys = len(module.in_keys)
-        attr_keys = [f"{in_key}_attr" for in_key in module.in_keys]
-        original_in_keys = [f"{in_key}_original" for in_key in module.in_keys]
-        baseline_keys = [f"{in_key}_baseline" for in_key in module.in_keys]
-        (_, attributor_module, *_) = super()._prepare_module(module)
+    def _prepare_module(
+        self, module: TensorDictModuleBase, in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
+    ) -> TensorDictModuleBase:
+        n_in_keys = len(in_keys)
+        saved_keys = [("saved", in_key) for in_key in in_keys]
+        attr_keys = [("attr", in_key) for in_key in in_keys]
+        baseline_keys = [("baseline", in_key) for in_key in in_keys]
+        (_, _, attributor_module, *_) = super()._prepare_module(module, in_keys, out_keys)
 
         modules = []
         modules.append(
             TensorDictModule(
-                lambda *tensors: tensors,
-                in_keys=module.in_keys,
-                out_keys=original_in_keys,
-                inplace=True,
-            )
-        )
-        modules.append(
-            TensorDictModule(
                 lambda *tensors: self._reduce_baselines_fn(tensors[:n_in_keys], tensors[n_in_keys:]),
-                in_keys=original_in_keys + baseline_keys,
-                out_keys=module.in_keys,
+                in_keys=in_keys + baseline_keys,
+                out_keys=saved_keys,
                 inplace=True,
             )
         )
-
         modules.append(
             TensorDictModule(
-                lambda *inputs: self._module_call_fn(inputs, module),
-                in_keys=module.in_keys,
-                out_keys=module.out_keys,
+                self._register_inputs_fn,
+                in_keys=saved_keys,
+                out_keys=saved_keys,
                 inplace=True,
+            )
+        )
+        modules.append(
+            FunctionModule(
+                lambda td: self._module_call_fn(td, module),
+                in_keys=saved_keys,
+                out_keys=out_keys,
             )
         )
         modules.append(attributor_module)
@@ -153,20 +159,17 @@ class GradientAttributionWithBaseline(GradientAttribution):
                     lambda *tensors: self._multiply_by_inputs_fn(
                         tensors[:n_in_keys], tensors[n_in_keys : n_in_keys * 2], tensors[n_in_keys * 2 :]
                     ),
-                    in_keys=original_in_keys + baseline_keys + attr_keys,
+                    in_keys=in_keys + baseline_keys + attr_keys,
                     out_keys=attr_keys,
                     inplace=True,
                 )
             )
         if self._compute_convergence_delta:
             modules.append(
-                TensorDictModule(
-                    lambda **tensors: self._compute_convergence_delta_fn(
-                        tensors, module.in_keys, module.out_keys, module
-                    ),
-                    in_keys={k: k for k in original_in_keys + baseline_keys + attr_keys + self._additional_init_keys},
+                FunctionModule(
+                    lambda td: self._compute_convergence_delta_fn(td, in_keys, out_keys, module),
+                    in_keys=in_keys + baseline_keys + attr_keys + self._additional_init_keys,
                     out_keys=["convergence_delta"],
-                    inplace=True,
                 )
             )
 
@@ -199,11 +202,11 @@ class GradientAttributionWithBaseline(GradientAttribution):
         pass
 
     @abstractmethod
-    def _module_call_fn(self, inputs: Tuple[torch.Tensor, ...], module: TensorDictModule) -> Tuple[torch.Tensor, ...]:
+    def _module_call_fn(self, td: TensorDict, module: TensorDictModuleBase) -> TensorDict:
         pass
 
     @torch.no_grad()
-    def _multiply_by_inputs_fn(
+    def _multiply_by_inputs_fn(  # TODO: is it faster with TensorDict?
         self, inputs: Tuple[torch.Tensor, ...], baselines: Tuple[torch.Tensor, ...], attrs: Tuple[torch.Tensor, ...]
     ) -> Tuple[torch.Tensor, ...]:
         return tuple(attr * (inp - baseline) for attr, inp, baseline in zip(attrs, inputs, baselines))
@@ -211,30 +214,30 @@ class GradientAttributionWithBaseline(GradientAttribution):
     @torch.no_grad()
     def _compute_convergence_delta_fn(
         self,
-        tensors: Dict[str, torch.Tensor],
-        in_keys: List[str],
-        out_keys: List[str],
-        module: TensorDictModule,
-    ) -> torch.Tensor:
-        tup_inputs = tuple(tensors[f"{k}_original"] for k in in_keys)
-        tup_baselines = tuple(tensors[f"{k}_baseline"] for k in in_keys)
-        tup_attrs = tuple(tensors[f"{k}_attr"] for k in in_keys)
+        td: TensorDict,
+        in_keys: List[UnraveledKey],
+        out_keys: List[UnraveledKey],
+        module: TensorDictModuleBase,
+    ) -> TensorDict:
+        baseline_keys = [("baseline", in_key) for in_key in in_keys]
+        attr_keys = [("attr", in_key) for in_key in in_keys]
 
-        additional_init_tensors = {k: tensors[k] for k in self._additional_init_keys}
-
-        batch_size = tup_inputs[0].shape[0]
+        inputs = td.select(*in_keys)
+        baselines = td.select(*baseline_keys)["baseline"]
+        attrs = td.select(*attr_keys)
+        additional_init_tensors = td.select(*self._additional_init_keys)
 
         if self._init_targets is not None:
-            start_out = self._init_targets(dict(zip(out_keys, module(*tup_baselines))), additional_init_tensors)
+            start_out = self._init_targets(module(baselines), additional_init_tensors)
         else:
-            start_out = dict(zip(out_keys, module(*tup_baselines)))
-        start_out_sum = sum(start_out[k].reshape(batch_size, -1).sum(dim=1) for k in start_out.keys())
+            start_out = module(baselines).select(*out_keys)
+        start_out_sum = start_out.sum(dim="feature", reduce=True)
         if self._init_targets is not None:
-            end_out = self._init_targets(dict(zip(out_keys, module(*tup_inputs))), additional_init_tensors)
+            end_out = self._init_targets(module(inputs), additional_init_tensors)
         else:
-            end_out = dict(zip(out_keys, module(*tup_inputs)))
-        end_out_sum = sum(end_out[k].reshape(batch_size, -1).sum(dim=1) for k in end_out.keys())
+            end_out = module(inputs).select(*out_keys)
+        end_out_sum = end_out.sum(dim="feature", reduce=True)
 
-        inputs_sums = torch.stack([attr.reshape(batch_size, -1).sum(dim=1) for attr in tup_attrs])
-        attr_sum = inputs_sums.sum(dim=0)
-        return attr_sum - (end_out_sum - start_out_sum)
+        attr_sum = attrs.sum(dim="feature", reduce=True)
+        td["convergence_delta"] = attr_sum - (end_out_sum - start_out_sum)
+        return td

--- a/src/tdhook/attribution/gradient_attribution/saliency.py
+++ b/src/tdhook/attribution/gradient_attribution/saliency.py
@@ -3,6 +3,7 @@ Saliency attribution
 """
 
 import torch
+from typing import Tuple
 
 from tdhook.attribution.gradient_attribution import GradientAttribution
 
@@ -12,6 +13,11 @@ class Saliency(GradientAttribution):
         super().__init__(*args, **kwargs)
         self._absolute = absolute
 
-    def _grad_attr(self, target, args, init_grad):
-        grads = torch.autograd.grad(target, args, init_grad)
+    def _grad_attr(
+        self,
+        targets: Tuple[torch.Tensor, ...],
+        inputs: Tuple[torch.Tensor, ...],
+        init_grads: Tuple[torch.Tensor, ...],
+    ):
+        grads = torch.autograd.grad(targets, inputs, init_grads)
         return tuple(grad.abs() if self._absolute else grad for grad in grads)

--- a/src/tdhook/attribution/gradient_attribution/saliency.py
+++ b/src/tdhook/attribution/gradient_attribution/saliency.py
@@ -2,10 +2,10 @@
 Saliency attribution
 """
 
-import torch
-from typing import Tuple
+from tensordict import TensorDict
 
 from tdhook.attribution.gradient_attribution import GradientAttribution
+from tdhook.module import td_grad
 
 
 class Saliency(GradientAttribution):
@@ -15,9 +15,11 @@ class Saliency(GradientAttribution):
 
     def _grad_attr(
         self,
-        targets: Tuple[torch.Tensor, ...],
-        inputs: Tuple[torch.Tensor, ...],
-        init_grads: Tuple[torch.Tensor, ...],
+        targets: TensorDict,
+        inputs: TensorDict,
+        init_grads: TensorDict,
     ):
-        grads = torch.autograd.grad(targets, inputs, init_grads)
-        return tuple(grad.abs() if self._absolute else grad for grad in grads)
+        grads = td_grad(targets, inputs, init_grads)
+        if self._absolute:
+            grads.abs_()
+        return grads

--- a/src/tdhook/attribution/lrp/lrp.py
+++ b/src/tdhook/attribution/lrp/lrp.py
@@ -2,14 +2,16 @@
 LRP
 """
 
-from typing import Callable, Optional, Dict, List
+from typing import Callable, Optional, List
 
 from torch import nn
-import torch
 from warnings import warn
-from tensordict.nn import TensorDictModule
+from tensordict.nn import TensorDictModule, TensorDictModuleBase
+from tensordict import TensorDict
 
 from tdhook.attribution.gradient_attribution import GradientAttribution
+from tdhook.module import td_grad
+from tdhook._types import UnraveledKey
 
 from .rules import Rule
 
@@ -18,13 +20,9 @@ class LRP(GradientAttribution):
     def __init__(
         self,
         rule_mapper: Callable[[str, nn.Module], Rule | None],
-        init_targets: Optional[
-            Callable[[Dict[str, torch.Tensor], Dict[str, torch.Tensor]], Dict[str, torch.Tensor]]
-        ] = None,
-        init_grads: Optional[
-            Callable[[Dict[str, torch.Tensor], Dict[str, torch.Tensor]], Dict[str, torch.Tensor]]
-        ] = None,
-        additional_init_keys: Optional[List[str]] = None,
+        init_targets: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
+        init_grads: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
+        additional_init_keys: Optional[List[UnraveledKey]] = None,
         warn_on_missing_rule: bool = True,
         skip_modules: Optional[Callable[[str, nn.Module], bool]] = None,
     ):
@@ -39,9 +37,8 @@ class LRP(GradientAttribution):
         self._skip_modules = skip_modules
 
     def _prepare_module(
-        self,
-        module: TensorDictModule,
-    ) -> TensorDictModule:
+        self, module: TensorDictModuleBase, in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
+    ) -> TensorDictModuleBase:
         rule_map = {}
         for name, child in module.named_modules():
             if self._skip_modules and self._skip_modules(name, child):
@@ -53,10 +50,12 @@ class LRP(GradientAttribution):
             elif self._warn_on_missing_rule:
                 warn(f"No rule found for module `{name}` ({type(child).__name__})")
         module._rule_map = rule_map
-        return super()._prepare_module(module)
+        return super()._prepare_module(module, in_keys, out_keys)
 
-    def _restore_module(self, module: TensorDictModule) -> TensorDictModule:
-        module = super()._restore_module(module)
+    def _restore_module(
+        self, module: TensorDictModuleBase, in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
+    ) -> TensorDictModuleBase:
+        module = super()._restore_module(module, in_keys, out_keys)
         for name, child in module.named_modules():
             rule = self._rule_mapper(name, child)
             if rule is not None:
@@ -64,8 +63,13 @@ class LRP(GradientAttribution):
         del module._rule_map
         return module
 
-    def _grad_attr(self, targets, inputs, init_grads):
-        return torch.autograd.grad(targets, inputs, init_grads)
+    def _grad_attr(
+        self,
+        targets: TensorDict,
+        inputs: TensorDict,
+        init_grads: TensorDict,
+    ) -> TensorDict:
+        return td_grad(targets, inputs, init_grads)
 
     @staticmethod
     def default_skip(name: str, module: nn.Module) -> bool:

--- a/src/tdhook/attribution/lrp/lrp.py
+++ b/src/tdhook/attribution/lrp/lrp.py
@@ -2,11 +2,12 @@
 LRP
 """
 
-from typing import Callable, Optional
+from typing import Callable, Optional, Dict, List
 
 from torch import nn
 import torch
 from warnings import warn
+from tensordict.nn import TensorDictModule
 
 from tdhook.attribution.gradient_attribution import GradientAttribution
 
@@ -17,20 +18,30 @@ class LRP(GradientAttribution):
     def __init__(
         self,
         rule_mapper: Callable[[str, nn.Module], Rule | None],
-        init_target: Optional[Callable] = None,
-        init_grad: Optional[Callable] = None,
+        init_targets: Optional[
+            Callable[[Dict[str, torch.Tensor], Dict[str, torch.Tensor]], Dict[str, torch.Tensor]]
+        ] = None,
+        init_grads: Optional[
+            Callable[[Dict[str, torch.Tensor], Dict[str, torch.Tensor]], Dict[str, torch.Tensor]]
+        ] = None,
+        additional_init_keys: Optional[List[str]] = None,
         warn_on_missing_rule: bool = True,
         skip_modules: Optional[Callable[[str, nn.Module], bool]] = None,
     ):
-        super().__init__(init_target, init_grad)
+        super().__init__(
+            init_targets=init_targets,
+            init_grads=init_grads,
+            multiply_by_inputs=False,
+            additional_init_keys=additional_init_keys,
+        )
         self._rule_mapper = rule_mapper
         self._warn_on_missing_rule = warn_on_missing_rule
         self._skip_modules = skip_modules
 
     def _prepare_module(
         self,
-        module: nn.Module,
-    ) -> nn.Module:
+        module: TensorDictModule,
+    ) -> TensorDictModule:
         rule_map = {}
         for name, child in module.named_modules():
             if self._skip_modules and self._skip_modules(name, child):
@@ -40,11 +51,12 @@ class LRP(GradientAttribution):
                 rule.register(child)
                 rule_map[name] = rule
             elif self._warn_on_missing_rule:
-                warn(f"No rule found for module `{name}`")
+                warn(f"No rule found for module `{name}` ({type(child).__name__})")
         module._rule_map = rule_map
-        return module
+        return super()._prepare_module(module)
 
-    def _restore_module(self, module: nn.Module) -> nn.Module:
+    def _restore_module(self, module: TensorDictModule) -> TensorDictModule:
+        module = super()._restore_module(module)
         for name, child in module.named_modules():
             rule = self._rule_mapper(name, child)
             if rule is not None:
@@ -52,9 +64,11 @@ class LRP(GradientAttribution):
         del module._rule_map
         return module
 
-    def _grad_attr(self, target, args, init_grad):
-        return torch.autograd.grad(target, args, init_grad)
+    def _grad_attr(self, targets, inputs, init_grads):
+        return torch.autograd.grad(targets, inputs, init_grads)
 
     @staticmethod
-    def skip_root_and_modulelist(name: str, module: nn.Module) -> bool:
-        return name == "" or isinstance(module, nn.ModuleList)
+    def default_skip(name: str, module: nn.Module) -> bool:
+        names_to_skip = ("", "td_module")
+        classes_to_skip = (nn.ModuleList, nn.Sequential, TensorDictModule)
+        return name in names_to_skip or isinstance(module, classes_to_skip)

--- a/src/tdhook/contexts.py
+++ b/src/tdhook/contexts.py
@@ -159,7 +159,5 @@ class CompositeHookingContextFactory(HookingContextFactory):
         return module
 
     def _hook_module(self, module: HookedModule) -> MultiHookHandle:
-        handles = []
-        for context in self._contexts:
-            handles.append(context._hook_module(module))
+        handles = [context._hook_module(module) for context in self._contexts]
         return MultiHookHandle(handles)

--- a/src/tdhook/contexts.py
+++ b/src/tdhook/contexts.py
@@ -53,6 +53,7 @@ class HookingContext:
         self._handle.remove()
         self._restore(self._module)
         self._in_context = False
+        del self._hooked_module  # TODO: check impact of this
         self._hooked_module = None
         self._handle = None
 

--- a/src/tdhook/hooks.py
+++ b/src/tdhook/hooks.py
@@ -111,7 +111,7 @@ class MultiHookHandle:
 
     def __add__(self, other: Any):
         if not isinstance(other, MultiHookHandle):
-            raise TypeError(f"MultiHookHandle cannot be added to {type(other)}")
+            raise TypeError(f"MultiHookHandle cannot be added to {type(other).__name__}")
         return MultiHookHandle(self._handles + other._handles)
 
 
@@ -221,7 +221,7 @@ class HookFactory:
                 value = args[value_index]
             if not isinstance(value, torch.Tensor):
                 raise RuntimeError(
-                    f"{type(value)} values are not supported for caching, use a `callback` to return a tensor"
+                    f"{type(value).__name__} values are not supported for caching, use a `callback` to return a tensor"
                 )
             cache[key] = value
 
@@ -251,7 +251,7 @@ class HookFactory:
                 value = callback(**dict(zip(params, args)), value=value)
             if type(value) is not original_type:
                 raise RuntimeError(
-                    f"Callback returned a value of type {type(value)} but the original value was of type {original_type}"
+                    f"Callback returned a value of type {type(value).__name__} but the original value was of type {original_type.__name__}"
                 )
             return value
 

--- a/src/tdhook/hooks.py
+++ b/src/tdhook/hooks.py
@@ -10,6 +10,7 @@ from tensordict import TensorDict
 import re
 from torch.utils.hooks import RemovableHandle
 from torch import nn
+import torch
 
 
 HookDirection = Literal["fwd", "bwd", "fwd_pre", "bwd_pre", "fwd_kwargs", "fwd_pre_kwargs"]
@@ -31,6 +32,8 @@ DIRECTION_TO_RETURN = {
     "fwd_kwargs": "output",
     "fwd_pre_kwargs": "args",
 }
+
+DIRECTION_TO_RETURN_INDEX = {k: v.index(DIRECTION_TO_RETURN[k]) for k, v in DIRECTION_TO_PARAMS.items()}
 
 DIRECTION_TO_TYPE = {
     "fwd": "output",
@@ -113,11 +116,12 @@ class MultiHookHandle:
 
 
 class MultiHookManager:
-    def __init__(self, pattern: Optional[str] = None):
+    def __init__(self, pattern: Optional[str] = None, relative: bool = False):
         if pattern is None:
             pattern = r"a^"  # match nothing by default
         self._pattern = pattern
         self._reg_exp = re.compile(pattern)
+        self._relative = relative
 
     @property
     def pattern(self) -> str:
@@ -140,6 +144,13 @@ class MultiHookManager:
         """Register the hook to the module."""
         handles = []
         for name, module in module.named_modules():
+            if self._relative:
+                if name.startswith("td_module"):
+                    name = name[len("td_module") :].lstrip(".")
+                if name.startswith("module"):
+                    name = name[len("module") :].lstrip(".")
+                if name == "":
+                    continue
             if self._reg_exp.match(name):
                 handles.append(register_hook_to_module(module, hook_factory(name), direction, prepend))
         return MultiHookHandle(handles)
@@ -208,8 +219,10 @@ class HookFactory:
                 value = callback(**dict(zip(params, args)), key=key)
             else:
                 value = args[value_index]
-            if isinstance(value, tuple):
-                raise RuntimeError("Tuple values are not supported for caching, use a `callback` to return a tensor")
+            if not isinstance(value, torch.Tensor):
+                raise RuntimeError(
+                    f"{type(value)} values are not supported for caching, use a `callback` to return a tensor"
+                )
             cache[key] = value
 
         return hook
@@ -226,11 +239,12 @@ class HookFactory:
             raise ValueError(f"Invalid direction: {direction}")
 
         params = DIRECTION_TO_PARAMS[direction]
+        return_index = DIRECTION_TO_RETURN_INDEX[direction]
         HookFactory._check_callback_signature(callback, set(params))
 
         def hook(*args):
-            nonlocal value, callback
-            original_type = type(value)
+            nonlocal value, callback, params, return_index
+            original_type = type(args[return_index])
             if isinstance(value, CacheProxy):
                 value = value.resolve()
             if callback is not None:

--- a/src/tdhook/metrics.py
+++ b/src/tdhook/metrics.py
@@ -27,7 +27,7 @@ class InfidelityMetric:
 
         for key in module.in_keys:
             # Get original attribution
-            original_attr = original_data.get(f"{key}_attr")
+            original_attr = original_data.get(("attr", key))
 
             # Generate multiple perturbations
             perturbation_scores = []
@@ -99,8 +99,8 @@ class SensitivityMetric:
         n_batch_dims = len(original_data.batch_size)
 
         for key in module.in_keys:
-            original_attr = original_data.get(f"{key}_attr")
-            perturbed_attr = perturbed_data.get(f"{key}_attr")
+            original_attr = original_data.get(("attr", key))
+            perturbed_attr = perturbed_data.get(("attr", key))
             explanation_diff = (original_attr - perturbed_attr).abs()
 
             # Calculate mean over all dimensions except the batch dimensions

--- a/src/tdhook/module.py
+++ b/src/tdhook/module.py
@@ -3,7 +3,7 @@ HookedModule
 """
 
 from torch.utils.hooks import RemovableHandle
-from tensordict.nn import TensorDictModule, TensorDictModuleWrapper
+from tensordict.nn import TensorDictModule, TensorDictModuleWrapper, TensorDictModuleBase
 from tensordict import TensorDict
 from typing import Callable, Any, Optional, Tuple, TYPE_CHECKING, List
 import torch
@@ -19,6 +19,7 @@ from tdhook.hooks import (
     HookDirection,
     DIRECTION_TO_TYPE,
 )
+from tdhook._types import UnraveledKey
 
 if TYPE_CHECKING:
     from tdhook.contexts import HookingContext
@@ -31,6 +32,56 @@ def get_best_device():
         return torch.device("mps")
     else:
         return torch.device("cpu")
+
+
+def td_grad(
+    outputs: TensorDict | Tuple[TensorDict, ...],
+    inputs: TensorDict | Tuple[TensorDict, ...],
+    grad_outputs: TensorDict | Tuple[TensorDict, ...],
+    **kwargs: Any,
+) -> TensorDict:
+    if isinstance(outputs, tuple) and len(outputs) > 1:
+        raise ValueError("torch.autograd.grad for TensorDict only supports a single output")
+    elif isinstance(outputs, tuple):
+        outputs = outputs[0]
+    if not isinstance(outputs, TensorDict):
+        raise ValueError("torch.autograd.grad for TensorDict only supports TensorDict as output")
+    else:
+        tup_outputs = tuple(outputs[k] for k in outputs.keys(True, True))
+
+    if isinstance(inputs, tuple) and len(inputs) > 1:
+        raise ValueError("torch.autograd.grad for TensorDict only supports a single input")
+    elif isinstance(inputs, tuple):
+        inputs = inputs[0]
+    if not isinstance(inputs, TensorDict):
+        raise ValueError("torch.autograd.grad for TensorDict only supports TensorDict as input")
+    else:
+        tup_inputs = tuple(inputs[k] for k in inputs.keys(True, True))
+
+    if grad_outputs is not None and isinstance(grad_outputs, tuple) and len(grad_outputs) > 1:
+        raise ValueError("torch.autograd.grad for TensorDict only supports a single grad_output")
+    elif isinstance(grad_outputs, tuple):
+        grad_outputs = grad_outputs[0]
+    if not isinstance(grad_outputs, TensorDict):
+        raise ValueError("torch.autograd.grad for TensorDict only supports TensorDict as grad_output")
+    else:
+        tup_grad_outputs = tuple(grad_outputs[k] for k in grad_outputs.keys(True, True))
+
+    tup_grads = torch.autograd.grad(tup_outputs, tup_inputs, tup_grad_outputs, **kwargs)
+    return TensorDict(dict(zip(inputs.keys(True, True), tup_grads)), batch_size=inputs.batch_size)
+
+
+class FunctionModule(TensorDictModuleBase):
+    def __init__(
+        self, td_fn: Callable[[TensorDict], TensorDict], in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
+    ):
+        super().__init__()
+        self.in_keys = in_keys
+        self.out_keys = out_keys
+        self._td_fn = td_fn
+
+    def forward(self, tensordict: TensorDict) -> TensorDict:
+        return self._td_fn(tensordict)
 
 
 class HookedModuleRun:

--- a/src/tdhook/module.py
+++ b/src/tdhook/module.py
@@ -41,7 +41,7 @@ class HookedModuleRun:
         self._outer_cache = cache
         self._name = run_name or "run"
         self._sep = run_sep or "."
-        self._cache = run_cache or TensorDict()
+        self._cache = TensorDict() if run_cache is None else run_cache
         self._grad_enabled = grad_enabled
         self._run_callback = run_callback or (lambda module, data: module(data))
 

--- a/src/tdhook/module.py
+++ b/src/tdhook/module.py
@@ -24,6 +24,15 @@ if TYPE_CHECKING:
     from tdhook.contexts import HookingContext
 
 
+def get_best_device():
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        return torch.device("mps")
+    else:
+        return torch.device("cpu")
+
+
 class HookedModuleRun:
     def __init__(
         self,
@@ -320,7 +329,7 @@ class HookedModule(TensorDictModuleWrapper):
     def forward(self, *args, **kwargs):
         if self._hooking_context is not None and not self._hooking_context._in_context:
             raise RuntimeError("Contextual HookedModule must be called in context")
-        return super().forward(*args, **kwargs)
+        return self.td_module(*args, **kwargs)
 
     @contextmanager
     def disable_context_hooks(self):

--- a/src/tdhook/weights/task_vectors.py
+++ b/src/tdhook/weights/task_vectors.py
@@ -7,54 +7,9 @@ from torch import nn
 from typing import Optional, Iterable, Callable, Generator, List
 from tensordict import TensorDict
 from contextlib import contextmanager
-from tensordict.nn import TensorDictModule
 
 from tdhook.contexts import HookingContextFactory, HookingContext
 from tdhook.module import HookedModule
-
-
-class TaskVectors(HookingContextFactory):
-    def __init__(
-        self,
-        alphas: Iterable[float],
-        get_test_accuracy: Callable[[nn.Module], float],
-        get_control_adequacy: Callable[[nn.Module], bool],
-    ):
-        self._context_kwargs = {
-            "alphas": alphas,
-            "get_test_accuracy": get_test_accuracy,
-            "get_control_adequacy": get_control_adequacy,
-        }
-
-    def prepare(
-        self,
-        module: nn.Module,
-        in_keys: Optional[List[str]] = None,
-        out_keys: Optional[List[str]] = None,
-    ) -> "TaskVectorsContext":
-        """
-        Prepare the module for execution.
-        """
-
-        return TaskVectorsContext(self, module, in_keys, out_keys, **self._context_kwargs)
-
-    def _spawn_hooked_module(
-        self, prep_module: nn.Module, in_keys: List[str], out_keys: List[str], hooking_context: "HookingContext"
-    ):
-        if isinstance(prep_module, TensorDictModule):
-            return TaskVectorsModule(
-                prep_module.module,
-                in_keys,
-                out_keys,
-                hooking_context=hooking_context,
-                inplace=prep_module.inplace,
-                method=prep_module.method,
-                method_kwargs=prep_module.method_kwargs,
-                strict=prep_module.strict,
-                get_kwargs=prep_module._get_kwargs,
-            )
-        else:
-            return TaskVectorsModule(prep_module, in_keys, out_keys, hooking_context=hooking_context)
 
 
 class TaskVectorsContext(HookingContext):
@@ -121,3 +76,32 @@ class TaskVectorsModule(HookedModule):
         """Apply vectors to model"""
         with self.get_weights(*vectors, alpha=alpha).to_module(self.module):
             yield self
+
+
+class TaskVectors(HookingContextFactory):
+    _hooking_context_class = TaskVectorsContext
+    _hooked_module_class = TaskVectorsModule
+
+    def __init__(
+        self,
+        alphas: Iterable[float],
+        get_test_accuracy: Callable[[nn.Module], float],
+        get_control_adequacy: Callable[[nn.Module], bool],
+    ):
+        self._context_kwargs = {
+            "alphas": alphas,
+            "get_test_accuracy": get_test_accuracy,
+            "get_control_adequacy": get_control_adequacy,
+        }
+
+    def prepare(
+        self,
+        module: nn.Module,
+        in_keys: Optional[List[str]] = None,
+        out_keys: Optional[List[str]] = None,
+    ) -> "TaskVectorsContext":
+        """
+        Prepare the module for execution.
+        """
+
+        return self._hooking_context_class(self, module, in_keys, out_keys, **self._context_kwargs)

--- a/tests/acteng/test_activation_caching.py
+++ b/tests/acteng/test_activation_caching.py
@@ -1,0 +1,33 @@
+"""
+Tests for the activation caching functionality.
+"""
+
+import torch
+
+from tdhook.acteng.activation_caching import ActivationCaching
+
+
+class TestActivationCaching:
+    """Test the ActivationCaching class."""
+
+    def test_activation_caching_context_creation(self, default_test_model):
+        """Test creating a ActivationCaching."""
+
+        context = ActivationCaching("td_module\.module\.linear2")
+        assert isinstance(context, ActivationCaching)
+
+        inputs = torch.randn(2, 10)
+        with context.prepare(default_test_model) as hooked_module:
+            hooked_module(inputs)
+        assert "td_module.module.linear2" in context.cache
+
+    def test_activation_caching_context_creation_relative(self, default_test_model):
+        """Test creating a ActivationCaching with relative naming."""
+
+        context = ActivationCaching("linear2", relative=True)
+        assert isinstance(context, ActivationCaching)
+
+        inputs = torch.randn(2, 10)
+        with context.prepare(default_test_model) as hooked_module:
+            hooked_module(inputs)
+        assert "linear2" in context.cache

--- a/tests/acteng/test_activation_caching.py
+++ b/tests/acteng/test_activation_caching.py
@@ -13,7 +13,7 @@ class TestActivationCaching:
     def test_activation_caching_context_creation(self, default_test_model):
         """Test creating a ActivationCaching."""
 
-        context = ActivationCaching("td_module\.module\.linear2")
+        context = ActivationCaching("td_module\.module\.linear2", relative=False)
         assert isinstance(context, ActivationCaching)
 
         inputs = torch.randn(2, 10)

--- a/tests/acteng/test_probing.py
+++ b/tests/acteng/test_probing.py
@@ -1,5 +1,5 @@
 """
-Tests for the latents functionality.
+Tests for the probing functionality.
 """
 
 import torch.nn as nn
@@ -17,10 +17,24 @@ class TestLinearProbing:
         def probe_factory(key, direction):
             return nn.Linear(20, 1)
 
-        context = LinearProbing("module\.linear2", probe_factory)
+        context = LinearProbing("td_module\.module\.linear2", probe_factory)
         assert isinstance(context, LinearProbing)
 
         inputs = torch.randn(2, 10)
         with context.prepare(default_test_model) as hooked_module:
             hooked_module(inputs)
-        assert "module.linear2" in context.cache
+        assert "td_module.module.linear2" in context.cache
+
+    def test_probing_context_creation_relative(self, default_test_model):
+        """Test creating a LinearProbing with relative naming."""
+
+        def probe_factory(key, direction):
+            return nn.Linear(20, 1)
+
+        context = LinearProbing("linear2", probe_factory, relative=True)
+        assert isinstance(context, LinearProbing)
+
+        inputs = torch.randn(2, 10)
+        with context.prepare(default_test_model) as hooked_module:
+            hooked_module(inputs)
+        assert "linear2" in context.cache

--- a/tests/acteng/test_probing.py
+++ b/tests/acteng/test_probing.py
@@ -17,7 +17,7 @@ class TestLinearProbing:
         def probe_factory(key, direction):
             return nn.Linear(20, 1)
 
-        context = LinearProbing("td_module\.module\.linear2", probe_factory)
+        context = LinearProbing("td_module\.module\.linear2", probe_factory, relative=False)
         assert isinstance(context, LinearProbing)
 
         inputs = torch.randn(2, 10)

--- a/tests/attribution/test_gradient.py
+++ b/tests/attribution/test_gradient.py
@@ -65,7 +65,7 @@ class TestGradientAttribution:
         with tdhook_context_factory.prepare(module) as hooked_module:
             output = hooked_module(TensorDict({"input": input_data}))
 
-        torch.testing.assert_close(output.get("input_attr"), attributions)
+        torch.testing.assert_close(output.get(("attr", "input")), attributions)
 
     @pytest.mark.parametrize(
         "factory",
@@ -86,7 +86,7 @@ class TestGradientAttribution:
         with tdhook_context_factory.prepare(module) as hooked_module:
             output = hooked_module(TensorDict({"input": input_data}))
 
-        torch.testing.assert_close(output.get("input_attr"), attributions)
+        torch.testing.assert_close(output.get(("attr", "input")), attributions)
 
     @pytest.mark.parametrize(
         "factory",
@@ -114,9 +114,9 @@ class TestGradientAttribution:
             compute_convergence_delta=True, multiply_by_inputs=multiply_by_inputs
         )
         with tdhook_context_factory.prepare(module) as hooked_module:
-            output = hooked_module(TensorDict({"input": input_data, "input_baseline": baseline}, batch_size=1))
+            output = hooked_module(TensorDict({"input": input_data, ("baseline", "input"): baseline}, batch_size=1))
 
-        torch.testing.assert_close(output.get("input_attr"), attributions)
+        torch.testing.assert_close(output.get(("attr", "input")), attributions)
         torch.testing.assert_close(output.get("convergence_delta"), convergence_delta)
 
     def test_requires_batched_hook(self):
@@ -127,7 +127,7 @@ class TestGradientAttribution:
         with pytest.raises(NotImplementedError):
             tdhook_context_factory = IntegratedGradients(compute_convergence_delta=True)
             with tdhook_context_factory.prepare(module) as hooked_module:
-                hooked_module(TensorDict({"input": input_data, "input_baseline": baseline}))
+                hooked_module(TensorDict({"input": input_data, ("baseline", "input"): baseline}))
 
 
 class TestGradientAttributionHelpers:

--- a/tests/attribution/test_lrp.py
+++ b/tests/attribution/test_lrp.py
@@ -206,7 +206,7 @@ class TestRules:
         original_output = tdhook_module(tdhook_input)
 
         lrp = LRP(
-            rule_mapper=tdhook_mapper, init_grad=lambda _: out_relevance, skip_modules=LRP.skip_root_and_modulelist
+            rule_mapper=tdhook_mapper, init_grads=lambda *_: {"output": out_relevance}, skip_modules=LRP.default_skip
         )
         with lrp.prepare(tdhook_module) as hooked_module:
             tdhook_output = hooked_module(TensorDict({"input": tdhook_input}))
@@ -227,7 +227,7 @@ class TestRules:
             with context_factory.prepare(module):
                 pass
 
-        clean_lrp = LRP(rule_mapper=EpsilonPlus(epsilon=1e-6), skip_modules=LRP.skip_root_and_modulelist)
+        clean_lrp = LRP(rule_mapper=EpsilonPlus(epsilon=1e-6), skip_modules=LRP.default_skip)
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             with clean_lrp.prepare(module):

--- a/tests/attribution/test_lrp.py
+++ b/tests/attribution/test_lrp.py
@@ -206,11 +206,13 @@ class TestRules:
         original_output = tdhook_module(tdhook_input)
 
         lrp = LRP(
-            rule_mapper=tdhook_mapper, init_grads=lambda *_: {"output": out_relevance}, skip_modules=LRP.default_skip
+            rule_mapper=tdhook_mapper,
+            init_grads=lambda *_: TensorDict({"output": out_relevance}),
+            skip_modules=LRP.default_skip,
         )
         with lrp.prepare(tdhook_module) as hooked_module:
             tdhook_output = hooked_module(TensorDict({"input": tdhook_input}))
-            tdhook_in_relevance = tdhook_output.get("input_attr")
+            tdhook_in_relevance = tdhook_output.get(("attr", "input"))
 
         with zennit_composite.context(zennit_module) as modified_module:
             zennit_output = modified_module(zennit_input)

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -5,12 +5,14 @@ Tests for the contexts functionality.
 import torch
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
+from typing import List
 
 import pytest
 
 from tdhook.contexts import HookingContextFactory, CompositeHookingContextFactory
 from tdhook.module import HookedModule
 from tdhook.hooks import MultiHookHandle
+from tdhook._types import UnraveledKey
 
 
 class Context1(HookingContextFactory):
@@ -37,11 +39,15 @@ class PrepFlagFactory(HookingContextFactory):
     def __init__(self, flag_name: str = "prep_flag"):
         self.flag_name = flag_name
 
-    def _prepare_module(self, module: TensorDictModule) -> TensorDictModule:
+    def _prepare_module(
+        self, module: TensorDictModule, in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
+    ) -> TensorDictModule:
         setattr(module, self.flag_name, 1)
         return module
 
-    def _restore_module(self, module: TensorDictModule) -> TensorDictModule:
+    def _restore_module(
+        self, module: TensorDictModule, in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
+    ) -> TensorDictModule:
         delattr(module, self.flag_name)
         return module
 

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -19,6 +19,7 @@ class Context1(HookingContextFactory):
             key="module",
             hook=lambda module, args, output: output + 1,
             direction="fwd",
+            relative=False,
         )
         return handle
 
@@ -29,6 +30,7 @@ class Context2(HookingContextFactory):
             key="module",
             hook=lambda module, args, output: output * 2,
             direction="fwd",
+            relative=False,
         )
         return handle
 

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -16,10 +16,9 @@ from tdhook.hooks import MultiHookHandle
 class Context1(HookingContextFactory):
     def _hook_module(self, module: HookedModule) -> MultiHookHandle:
         handle = module.register_submodule_hook(
-            key="module",
+            key="",
             hook=lambda module, args, output: output + 1,
             direction="fwd",
-            relative=False,
         )
         return handle
 
@@ -27,10 +26,9 @@ class Context1(HookingContextFactory):
 class Context2(HookingContextFactory):
     def _hook_module(self, module: HookedModule) -> MultiHookHandle:
         handle = module.register_submodule_hook(
-            key="module",
+            key="",
             hook=lambda module, args, output: output * 2,
             direction="fwd",
-            relative=False,
         )
         return handle
 
@@ -39,12 +37,12 @@ class PrepFlagFactory(HookingContextFactory):
     def __init__(self, flag_name: str = "prep_flag"):
         self.flag_name = flag_name
 
-    def _prepare_module(self, module):
-        setattr(module, self.flag_name, getattr(module, self.flag_name, 0) + 1)
+    def _prepare_module(self, module: TensorDictModule) -> TensorDictModule:
+        setattr(module, self.flag_name, 1)
         return module
 
-    def _restore_module(self, module):
-        setattr(module, self.flag_name, getattr(module, self.flag_name, 0) - 1)
+    def _restore_module(self, module: TensorDictModule) -> TensorDictModule:
+        delattr(module, self.flag_name)
         return module
 
 
@@ -186,13 +184,13 @@ class TestTensorDictModuleContext:
     def test_prepare_and_restore_td_module_calls_wrapped_prepare_restore(self, default_test_model):
         """Prepare/restore of a TensorDictModule uses factory hooks on wrapped module."""
         td_mod = TensorDictModule(module=default_test_model, in_keys=["input"], out_keys=["output"])
-        assert not hasattr(td_mod.module, "prep_flag") or getattr(td_mod.module, "prep_flag") == 0
+        assert not hasattr(td_mod, "prep_flag")
 
         ctx = PrepFlagFactory().prepare(td_mod)
         with ctx as hm:
             assert isinstance(hm, HookedModule)
-            assert getattr(td_mod.module, "prep_flag") == 1
-        assert getattr(td_mod.module, "prep_flag") == 0
+            assert getattr(td_mod, "prep_flag") == 1
+        assert not hasattr(td_mod, "prep_flag")
 
     def test_in_out_keys_default_from_td_module(self, default_test_model):
         """HookingContext defaults in/out keys from the TensorDictModule."""
@@ -213,13 +211,13 @@ class TestCompositeTensorDictModule:
         c1 = PrepFlagFactory("flag1")
         c2 = PrepFlagFactory("flag2")
         composite = CompositeHookingContextFactory(c1, c2)
-        assert getattr(td_mod.module, "flag1", 0) == 0
-        assert getattr(td_mod.module, "flag2", 0) == 0
+        assert not hasattr(td_mod, "flag1")
+        assert not hasattr(td_mod, "flag2")
         with composite.prepare(td_mod):
-            assert getattr(td_mod.module, "flag1", 0) == 1
-            assert getattr(td_mod.module, "flag2", 0) == 1
-        assert getattr(td_mod.module, "flag1", 0) == 0
-        assert getattr(td_mod.module, "flag2", 0) == 0
+            assert getattr(td_mod, "flag1") == 1
+            assert getattr(td_mod, "flag2") == 1
+        assert not hasattr(td_mod, "flag1")
+        assert not hasattr(td_mod, "flag2")
 
     def test_composite_raises_on_bad_spawn_override(self, default_test_model):
         """Composite rejects contexts overriding _spawn_hooked_module."""

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -4,14 +4,13 @@ Tests for the contexts functionality.
 
 import torch
 from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+
+import pytest
 
 from tdhook.contexts import HookingContextFactory, CompositeHookingContextFactory
 from tdhook.module import HookedModule
 from tdhook.hooks import MultiHookHandle
-
-import pytest
-
-from tensordict.nn import TensorDictModule
 
 
 class Context1(HookingContextFactory):

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -16,14 +16,14 @@ class TestHookedModule:
 
     def test_hooked_module_creation(self, default_test_model):
         """Test creating a HookedModule from a regular model."""
-        hooked_module = HookedModule(default_test_model, in_keys=["input"], out_keys=["output"])
+        hooked_module = HookedModule.from_module(default_test_model, in_keys=["input"], out_keys=["output"])
         td_output = hooked_module(TensorDict({"input": torch.randn(2, 3, 10)}, batch_size=[2, 3]))
         assert td_output["output"].shape == (2, 3, 5)
         assert torch.allclose(td_output["output"], default_test_model(td_output["input"]))
 
     def test_hooked_module_run(self, default_test_model):
         """Test creating a HookedModuleRun."""
-        hooked_module = HookedModule(default_test_model, in_keys=["input"], out_keys=["output"])
+        hooked_module = HookedModule.from_module(default_test_model, in_keys=["input"], out_keys=["output"])
         data = TensorDict({"input": torch.randn(2, 10)}, batch_size=[2])
 
         with hooked_module.run(data):
@@ -33,7 +33,7 @@ class TestHookedModule:
 
     def test_cache_proxy(self, default_test_model):
         """Test the CacheProxy class."""
-        hooked_module = HookedModule(default_test_model, in_keys=["input"], out_keys=["output"])
+        hooked_module = HookedModule.from_module(default_test_model, in_keys=["input"], out_keys=["output"])
         data = TensorDict({"input": torch.randn(2, 10)}, batch_size=[2])
 
         with hooked_module.run(data) as run:
@@ -50,7 +50,7 @@ class TestHookedModuleGetSet:
     def test_get(self, get_model):
         """Test getting a value."""
         nnsight_model = NNsight(get_model())
-        hooked_module = HookedModule(get_model(), in_keys=["input"], out_keys=["output"])
+        hooked_module = HookedModule.from_module(get_model(), in_keys=["input"], out_keys=["output"])
         input_data = torch.randn(2, 10)
 
         with nnsight_model.trace(input_data):
@@ -78,7 +78,7 @@ class TestHookedModuleGetSet:
         """Test setting a value."""
 
         nnsight_model = NNsight(get_model())
-        hooked_module = HookedModule(get_model(), in_keys=["input"], out_keys=["output"])
+        hooked_module = HookedModule.from_module(get_model(), in_keys=["input"], out_keys=["output"])
         input_data = torch.randn(2, 10)
         intervention_data = torch.randn(2, 20)
 
@@ -106,7 +106,7 @@ class TestHookedModuleGetSet:
     def test_get_input(self, get_model):
         """Test getting and saving input (pre-forward) values."""
         nnsight_model = NNsight(get_model())
-        hooked_module = HookedModule(get_model(), in_keys=["input"], out_keys=["output"])
+        hooked_module = HookedModule.from_module(get_model(), in_keys=["input"], out_keys=["output"])
         input_data = torch.randn(2, 10)
 
         with nnsight_model.trace(input_data):
@@ -132,7 +132,7 @@ class TestHookedModuleGetSet:
     def test_set_input(self, get_model):
         """Test setting input via pre-forward hook."""
         nnsight_model = NNsight(get_model())
-        hooked_module = HookedModule(get_model(), in_keys=["input"], out_keys=["output"])
+        hooked_module = HookedModule.from_module(get_model(), in_keys=["input"], out_keys=["output"])
         input_data = torch.randn(2, 10)
         intervention_input = torch.randn(2, 20)
 
@@ -161,7 +161,7 @@ class TestHookedModuleGetSet:
     def test_get_grad(self, get_model):
         """Test getting and saving grad (backward) values."""
         nnsight_model = NNsight(get_model())
-        hooked_module = HookedModule(get_model(), in_keys=["input"], out_keys=["output"])
+        hooked_module = HookedModule.from_module(get_model(), in_keys=["input"], out_keys=["output"])
         input_data = torch.randn(2, 10, requires_grad=True)
 
         with nnsight_model.trace(input_data):
@@ -204,7 +204,7 @@ class TestHookedModuleGetSet:
     def test_set_grad(self, get_model):
         """Test setting backward gradients to zero stops upstream grads."""
         model = get_model()
-        hooked_module = HookedModule(model, in_keys=["input"], out_keys=["output"])
+        hooked_module = HookedModule.from_module(model, in_keys=["input"], out_keys=["output"])
         input_data = torch.randn(2, 10, requires_grad=True)
 
         td = TensorDict({"input": input_data.clone().detach().requires_grad_(True)})
@@ -237,7 +237,7 @@ class TestHookedModuleGetSet:
     def test_get_grad_output(self, get_model):
         """Test getting and saving grad_input (backward pre-hook) values."""
         nnsight_model = NNsight(get_model())
-        hooked_module = HookedModule(get_model(), in_keys=["input"], out_keys=["output"])
+        hooked_module = HookedModule.from_module(get_model(), in_keys=["input"], out_keys=["output"])
         input_data = torch.randn(2, 10, requires_grad=True)
 
         with nnsight_model.trace(input_data):
@@ -278,7 +278,7 @@ class TestHookedModuleGetSet:
 
     def test_set_grad_output(self, get_model):
         model = get_model()
-        hooked_module = HookedModule(model, in_keys=["input"], out_keys=["output"])
+        hooked_module = HookedModule.from_module(model, in_keys=["input"], out_keys=["output"])
         input_data = torch.randn(2, 10, requires_grad=True)
 
         # Baseline: compute grad for linear1.weight
@@ -317,7 +317,7 @@ class TestHookedModuleGetSet:
 
 class TestStopAndErrors:
     def test_stop_prevents_later_layers(self, get_model):
-        hooked_module = HookedModule(get_model(), in_keys=["input"], out_keys=["output"])
+        hooked_module = HookedModule.from_module(get_model(), in_keys=["input"], out_keys=["output"])
         input_data = torch.randn(2, 10)
 
         called = False
@@ -335,7 +335,7 @@ class TestStopAndErrors:
         assert not called
 
     def test_run_methods_outside_context_raise(self, get_model):
-        hooked_module = HookedModule(get_model(), in_keys=["input"], out_keys=["output"])
+        hooked_module = HookedModule.from_module(get_model(), in_keys=["input"], out_keys=["output"])
         td = TensorDict({"input": torch.randn(2, 10)})
         run = hooked_module.run(td)
 
@@ -347,7 +347,7 @@ class TestStopAndErrors:
             run.set("module.linear2", torch.randn(2, 20))
 
     def test_invalid_submodule_path_raises(self, get_model):
-        hooked_module = HookedModule(get_model(), in_keys=["input"], out_keys=["output"])
+        hooked_module = HookedModule.from_module(get_model(), in_keys=["input"], out_keys=["output"])
         cache = TensorDict()
         with pytest.raises(ValueError):
             hooked_module.get(cache, "module.missing")
@@ -355,7 +355,7 @@ class TestStopAndErrors:
             hooked_module.set("module.missing", torch.randn(2, 20))
 
     def test_invalid_direction_raises(self, get_model):
-        hooked_module = HookedModule(get_model(), in_keys=["input"], out_keys=["output"])
+        hooked_module = HookedModule.from_module(get_model(), in_keys=["input"], out_keys=["output"])
         cache = TensorDict()
         with pytest.raises((KeyError, ValueError)):
             hooked_module.get(cache, "module.linear2", direction="invalid")
@@ -363,7 +363,7 @@ class TestStopAndErrors:
             hooked_module.set("module.linear2", torch.randn(2, 20), direction="invalid")
 
     def test_callback_signature_mismatch_raises(self, get_model):
-        hooked_module = HookedModule(get_model(), in_keys=["input"], out_keys=["output"])
+        hooked_module = HookedModule.from_module(get_model(), in_keys=["input"], out_keys=["output"])
         cache = TensorDict()
         # fwd_pre expects (module, args); missing 'args' -> error
         with pytest.raises(ValueError):
@@ -373,7 +373,7 @@ class TestStopAndErrors:
             hooked_module.get(cache, "module.linear2", direction="bwd", callback=lambda module: None)
 
     def test_tuple_caching_without_callback_raises(self, get_model):
-        hooked_module = HookedModule(get_model(), in_keys=["input"], out_keys=["output"])
+        hooked_module = HookedModule.from_module(get_model(), in_keys=["input"], out_keys=["output"])
         td = TensorDict({"input": torch.randn(2, 10)})
         cache = TensorDict()
         handle, _ = hooked_module.get(cache, "module.linear2", direction="fwd_pre")
@@ -384,7 +384,7 @@ class TestStopAndErrors:
 
 class TestAdditionalCoverage:
     def test_run_cache_setter_and_exception_path(self, get_model):
-        hooked_module = HookedModule(get_model(), in_keys=["input"], out_keys=["output"])
+        hooked_module = HookedModule.from_module(get_model(), in_keys=["input"], out_keys=["output"])
         td = TensorDict({"input": torch.randn(2, 10)})
         outer_cache = TensorDict()
         # exercise cache setter (line 62)
@@ -408,13 +408,13 @@ class TestAdditionalCoverage:
                 return self.linear_out(x)
 
         m = WithList()
-        hm = HookedModule(m, in_keys=["input"], out_keys=["output"])
+        hm = HookedModule.from_module(m, in_keys=["input"], out_keys=["output"])
         with pytest.warns(UserWarning):
             handle = hm.register_submodule_hook("module.layers", lambda module, args, output: output, direction="fwd")
             handle.remove()
 
     def test_module_wrappers_shortcuts(self, get_model):
-        hooked_module = HookedModule(get_model(), in_keys=["input"], out_keys=["output"])
+        hooked_module = HookedModule.from_module(get_model(), in_keys=["input"], out_keys=["output"])
         x = torch.randn(2, 10, requires_grad=True)
         cache = TensorDict()
         h_in, _ = hooked_module.get_input(cache, "module.linear2", callback=lambda **kw: kw["args"][0])
@@ -426,7 +426,7 @@ class TestAdditionalCoverage:
 
     def test_set_get_grad_output_wrappers(self, get_model):
         model = get_model()
-        hooked_module = HookedModule(model, in_keys=["input"], out_keys=["output"])
+        hooked_module = HookedModule.from_module(model, in_keys=["input"], out_keys=["output"])
         x = torch.randn(2, 10, requires_grad=True)
         h_set = hooked_module.set_grad_output("module.linear2", (torch.zeros(2, 20),))
         cache = TensorDict()
@@ -439,12 +439,14 @@ class TestAdditionalCoverage:
     def test_forward_guard_and_context_managers(self, get_model):
         # forward() guard (line 302)
         dummy_ctx = type("C", (), {"_in_context": False})()
-        hm_guard = HookedModule(get_model(), in_keys=["input"], out_keys=["output"], hooking_context=dummy_ctx)
+        hm_guard = HookedModule.from_module(
+            get_model(), in_keys=["input"], out_keys=["output"], hooking_context=dummy_ctx
+        )
         with pytest.raises(RuntimeError):
             hm_guard(TensorDict({"input": torch.randn(1, 10)}))
 
         # disable_context_hooks without context (307-310) and disable_context without context (315)
-        hm = HookedModule(get_model(), in_keys=["input"], out_keys=["output"])
+        hm = HookedModule.from_module(get_model(), in_keys=["input"], out_keys=["output"])
         with pytest.raises(RuntimeError):
             with hm.disable_context_hooks():
                 pass

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -37,7 +37,7 @@ class TestHookedModule:
         data = TensorDict({"input": torch.randn(2, 10)}, batch_size=[2])
 
         with hooked_module.run(data) as run:
-            proxy = run.get("module")
+            proxy = run.get("linear3")
             with pytest.raises(ValueError):
                 proxy.resolve()
 
@@ -58,18 +58,18 @@ class TestHookedModuleGetSet:
 
         save_cache = TensorDict()
         with hooked_module.run(TensorDict({"input": input_data}), cache=save_cache) as run:
-            run_proxy = run.get("module.linear2")
-            save_proxy = run.save("module.linear2")
+            run_proxy = run.get("linear2")
+            save_proxy = run.save("linear2")
 
         cache = TensorDict()
-        handle, proxy = hooked_module.get(cache, "module.linear2")
+        handle, proxy = hooked_module.get(cache, "linear2")
         hooked_module(TensorDict({"input": input_data}))
         handle.remove()
 
-        assert run_proxy.resolve() is run.cache["module.linear2_output"]
-        assert save_proxy.resolve() is save_cache["run.module.linear2_output"]
+        assert run_proxy.resolve() is run.cache["linear2_output"]
+        assert save_proxy.resolve() is save_cache["run.linear2_output"]
         assert save_proxy.resolve() is run_proxy.resolve()
-        assert proxy.resolve() is cache["module.linear2_output"]
+        assert proxy.resolve() is cache["linear2_output"]
 
         assert torch.allclose(run_proxy.resolve(), nnsight_state)
         assert torch.allclose(proxy.resolve(), nnsight_state)
@@ -90,9 +90,9 @@ class TestHookedModuleGetSet:
 
         shuttle_ctx = TensorDict({"input": input_data})
         with hooked_module.run(shuttle_ctx) as run:
-            run.set("module.linear2", intervention_data)
+            run.set("linear2", intervention_data)
 
-        handle = hooked_module.set("module.linear2", intervention_data)
+        handle = hooked_module.set("linear2", intervention_data)
         shuttle_out_ctx = TensorDict({"input": input_data})
         hooked_module(shuttle_out_ctx)
         handle.remove()
@@ -114,20 +114,20 @@ class TestHookedModuleGetSet:
 
         save_cache = TensorDict()
         with hooked_module.run(TensorDict({"input": input_data}), cache=save_cache) as run:
-            run_proxy = run.get_input("module.linear2", callback=lambda **kwargs: kwargs["args"][0])
-            save_proxy = run.save_input("module.linear2", callback=lambda **kwargs: kwargs["args"][0])
+            run_proxy = run.get_input("linear2", callback=lambda **kwargs: kwargs["args"][0])
+            save_proxy = run.save_input("linear2", callback=lambda **kwargs: kwargs["args"][0])
 
         cache = TensorDict()
         handle, proxy = hooked_module.get(
-            cache, "module.linear2", direction="fwd_pre", callback=lambda **kwargs: kwargs["args"][0]
+            cache, "linear2", direction="fwd_pre", callback=lambda **kwargs: kwargs["args"][0]
         )
         hooked_module(TensorDict({"input": input_data}))
         handle.remove()
 
         assert torch.allclose(run_proxy.resolve(), nnsight_input)
         assert torch.allclose(proxy.resolve(), nnsight_input)
-        assert run_proxy.resolve() is run.cache["module.linear2_input"]
-        assert save_proxy.resolve() is save_cache["run.module.linear2_input"]
+        assert run_proxy.resolve() is run.cache["linear2_input"]
+        assert save_proxy.resolve() is save_cache["run.linear2_input"]
 
     def test_set_input(self, get_model):
         """Test setting input via pre-forward hook."""
@@ -145,9 +145,9 @@ class TestHookedModuleGetSet:
         td_ctx = TensorDict({"input": input_data})
         with hooked_module.run(td_ctx) as run:
             # For pre hooks, value should be args tuple
-            run.set_input("module.linear2", (intervention_input,))
+            run.set_input("linear2", (intervention_input,))
 
-        handle = hooked_module.set_input("module.linear2", (intervention_input,))
+        handle = hooked_module.set_input("linear2", (intervention_input,))
         td_ctx2 = TensorDict({"input": input_data})
         hooked_module(td_ctx2)
         handle.remove()
@@ -181,13 +181,13 @@ class TestHookedModuleGetSet:
             grad_enabled=True,
             run_callback=run_with_backward,
         ) as run:
-            run_proxy = run.get_grad("module.linear2", callback=lambda **kwargs: kwargs["grad_input"][0])
-            save_proxy = run.save_grad("module.linear2", callback=lambda **kwargs: kwargs["grad_input"][0])
+            run_proxy = run.get_grad("linear2", callback=lambda **kwargs: kwargs["grad_input"][0])
+            save_proxy = run.save_grad("linear2", callback=lambda **kwargs: kwargs["grad_input"][0])
 
         cache = TensorDict()
         handle, proxy = hooked_module.get_grad(
             cache,
-            "module.linear2",
+            "linear2",
             callback=lambda **kwargs: kwargs["grad_input"][0],
         )
         td = TensorDict({"input": input_data.detach().clone().requires_grad_(True)})
@@ -198,8 +198,8 @@ class TestHookedModuleGetSet:
         # For backward hooks, wrapper and direct get use callbacks to return the grad_output tensor
         assert torch.allclose(run_proxy.resolve(), nnsight_grad)
         assert torch.allclose(proxy.resolve(), nnsight_grad)
-        assert run_proxy.resolve() is run.cache["module.linear2_grad_input"]
-        assert save_proxy.resolve() is save_cache["run.module.linear2_grad_input"]
+        assert run_proxy.resolve() is run.cache["linear2_grad_input"]
+        assert save_proxy.resolve() is save_cache["run.linear2_grad_input"]
 
     def test_set_grad(self, get_model):
         """Test setting backward gradients to zero stops upstream grads."""
@@ -222,14 +222,14 @@ class TestHookedModuleGetSet:
             out.sum().backward()
 
         with hooked_module.run(td2, grad_enabled=True, run_callback=run_with_backward) as run:
-            run.set_grad("module.linear2", (zero_like,))
+            run.set_grad("linear2", (zero_like,))
         grad_after_pre = model.linear1.weight.grad.clone()
         assert torch.allclose(grad_after_pre, torch.zeros_like(grad_after_pre))
         model.zero_grad(set_to_none=True)
 
         td3 = TensorDict({"input": input_data.clone().detach().requires_grad_(True)})
         with hooked_module.run(td3, grad_enabled=True, run_callback=run_with_backward) as run:
-            run.set_grad("module.linear2", (zero_like,))
+            run.set_grad("linear2", (zero_like,))
         grad_after_full = model.linear1.weight.grad.clone()
         assert torch.allclose(grad_after_full, torch.zeros_like(grad_after_full))
         assert not torch.allclose(baseline_grad, torch.zeros_like(baseline_grad))
@@ -257,13 +257,13 @@ class TestHookedModuleGetSet:
             grad_enabled=True,
             run_callback=run_with_backward,
         ) as run:
-            run_proxy = run.get_grad_output("module.linear2", callback=lambda **kwargs: kwargs["grad_output"][0])
-            save_proxy = run.save_grad_output("module.linear2", callback=lambda **kwargs: kwargs["grad_output"][0])
+            run_proxy = run.get_grad_output("linear2", callback=lambda **kwargs: kwargs["grad_output"][0])
+            save_proxy = run.save_grad_output("linear2", callback=lambda **kwargs: kwargs["grad_output"][0])
 
         cache = TensorDict()
         handle, proxy = hooked_module.get_grad_output(
             cache,
-            "module.linear2",
+            "linear2",
             callback=lambda **kwargs: kwargs["grad_output"][0],
         )
         td = TensorDict({"input": input_data.detach().clone().requires_grad_(True)})
@@ -273,8 +273,8 @@ class TestHookedModuleGetSet:
 
         assert torch.allclose(run_proxy.resolve(), nnsight_grad_in)
         assert torch.allclose(proxy.resolve(), nnsight_grad_in)
-        assert run_proxy.resolve() is run.cache["module.linear2_grad_output"]
-        assert save_proxy.resolve() is save_cache["run.module.linear2_grad_output"]
+        assert run_proxy.resolve() is run.cache["linear2_grad_output"]
+        assert save_proxy.resolve() is save_cache["run.linear2_grad_output"]
 
     def test_set_grad_output(self, get_model):
         model = get_model()
@@ -298,13 +298,13 @@ class TestHookedModuleGetSet:
             out.sum().backward()
 
         with hooked_module.run(td2, grad_enabled=True, run_callback=run_with_backward) as run:
-            run.set_grad_output("module.linear2", (zero_like,))
+            run.set_grad_output("linear2", (zero_like,))
         grad_after_pre = model.linear1.weight.grad.clone()
         assert torch.allclose(grad_after_pre, torch.zeros_like(grad_after_pre))
         model.zero_grad(set_to_none=True)
 
         # Using module-level wrapper: set grad_output at linear2 to zero
-        handle = hooked_module.set_grad_output("module.linear2", (zero_like,))
+        handle = hooked_module.set_grad_output("linear2", (zero_like,))
         td3 = TensorDict({"input": input_data.clone().detach().requires_grad_(True)})
         out = hooked_module(td3)["output"]
         out.sum().backward()
@@ -329,7 +329,7 @@ class TestStopAndErrors:
         handle_pre = hooked_module.module.linear3.register_forward_pre_hook(hook)
 
         with hooked_module.run(TensorDict({"input": input_data})) as run:
-            run.stop("module.linear2")
+            run.stop("linear2")
         handle_pre.remove()
 
         assert not called
@@ -340,11 +340,11 @@ class TestStopAndErrors:
         run = hooked_module.run(td)
 
         with pytest.raises(RuntimeError):
-            run.get("module.linear2")
+            run.get("linear2")
         with pytest.raises(RuntimeError):
-            run.save("module.linear2")
+            run.save("linear2")
         with pytest.raises(RuntimeError):
-            run.set("module.linear2", torch.randn(2, 20))
+            run.set("linear2", torch.randn(2, 20))
 
     def test_invalid_submodule_path_raises(self, get_model):
         hooked_module = HookedModule.from_module(get_model(), in_keys=["input"], out_keys=["output"])
@@ -358,25 +358,25 @@ class TestStopAndErrors:
         hooked_module = HookedModule.from_module(get_model(), in_keys=["input"], out_keys=["output"])
         cache = TensorDict()
         with pytest.raises((KeyError, ValueError)):
-            hooked_module.get(cache, "module.linear2", direction="invalid")
+            hooked_module.get(cache, "linear2", direction="invalid")
         with pytest.raises((KeyError, ValueError)):
-            hooked_module.set("module.linear2", torch.randn(2, 20), direction="invalid")
+            hooked_module.set("linear2", torch.randn(2, 20), direction="invalid")
 
     def test_callback_signature_mismatch_raises(self, get_model):
         hooked_module = HookedModule.from_module(get_model(), in_keys=["input"], out_keys=["output"])
         cache = TensorDict()
         # fwd_pre expects (module, args); missing 'args' -> error
         with pytest.raises(ValueError):
-            hooked_module.get(cache, "module.linear2", direction="fwd_pre", callback=lambda module: None)
+            hooked_module.get(cache, "linear2", direction="fwd_pre", callback=lambda module: None)
         # bwd expects (module, grad_input, grad_output); missing 'grad_input'/'grad_output' -> error
         with pytest.raises(ValueError):
-            hooked_module.get(cache, "module.linear2", direction="bwd", callback=lambda module: None)
+            hooked_module.get(cache, "linear2", direction="bwd", callback=lambda module: None)
 
     def test_tuple_caching_without_callback_raises(self, get_model):
         hooked_module = HookedModule.from_module(get_model(), in_keys=["input"], out_keys=["output"])
         td = TensorDict({"input": torch.randn(2, 10)})
         cache = TensorDict()
-        handle, _ = hooked_module.get(cache, "module.linear2", direction="fwd_pre")
+        handle, _ = hooked_module.get(cache, "linear2", direction="fwd_pre")
         with pytest.raises((ValueError, RuntimeError)):
             hooked_module(td)
         handle.remove()
@@ -410,15 +410,15 @@ class TestAdditionalCoverage:
         m = WithList()
         hm = HookedModule.from_module(m, in_keys=["input"], out_keys=["output"])
         with pytest.warns(UserWarning):
-            handle = hm.register_submodule_hook("module.layers", lambda module, args, output: output, direction="fwd")
+            handle = hm.register_submodule_hook("layers", lambda module, args, output: output, direction="fwd")
             handle.remove()
 
     def test_module_wrappers_shortcuts(self, get_model):
         hooked_module = HookedModule.from_module(get_model(), in_keys=["input"], out_keys=["output"])
         x = torch.randn(2, 10, requires_grad=True)
         cache = TensorDict()
-        h_in, _ = hooked_module.get_input(cache, "module.linear2", callback=lambda **kw: kw["args"][0])
-        h_setg = hooked_module.set_grad("module.linear2", (torch.zeros(2, 20),))
+        h_in, _ = hooked_module.get_input(cache, "linear2", callback=lambda **kw: kw["args"][0])
+        h_setg = hooked_module.set_grad("linear2", (torch.zeros(2, 20),))
         out = hooked_module(TensorDict({"input": x}))["output"]
         out.sum().backward()
         h_in.remove()
@@ -428,9 +428,9 @@ class TestAdditionalCoverage:
         model = get_model()
         hooked_module = HookedModule.from_module(model, in_keys=["input"], out_keys=["output"])
         x = torch.randn(2, 10, requires_grad=True)
-        h_set = hooked_module.set_grad_output("module.linear2", (torch.zeros(2, 20),))
+        h_set = hooked_module.set_grad_output("linear2", (torch.zeros(2, 20),))
         cache = TensorDict()
-        h_get, _ = hooked_module.get_grad_output(cache, "module.linear2", callback=lambda **kw: kw["grad_output"][0])
+        h_get, _ = hooked_module.get_grad_output(cache, "linear2", callback=lambda **kw: kw["grad_output"][0])
         out = hooked_module(TensorDict({"input": x}))["output"]
         out.sum().backward()
         h_set.remove()

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "absl-py"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/2a/c93173ffa1b39c1d0395b7e842bbdc62e556ca9d8d3b5572926f3e4ca752/absl_py-2.3.1.tar.gz", hash = "sha256:a97820526f7fbfd2ec1bce83f3f25e3a14840dac0d8e02a0b71cd75db3f77fc9", size = 116588, upload-time = "2025-07-03T09:31:44.05Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/aa/ba0014cc4659328dc818a28827be78e6d97312ab0cb98105a770924dc11e/absl_py-2.3.1-py3-none-any.whl", hash = "sha256:eeecf07f0c2a93ace0772c92e596ace6d3d3996c042b2128459aaae2a76de11d", size = 135811, upload-time = "2025-07-03T09:31:42.253Z" },
+]
+
+[[package]]
 name = "accelerate"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -862,6 +871,23 @@ wheels = [
 ]
 
 [[package]]
+name = "etils"
+version = "1.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/a0/522bbff0f3cdd37968f90dd7f26c7aa801ed87f5ba335f156de7f2b88a48/etils-1.13.0.tar.gz", hash = "sha256:a5b60c71f95bcd2d43d4e9fb3dc3879120c1f60472bb5ce19f7a860b1d44f607", size = 106368, upload-time = "2025-07-15T10:29:10.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/98/87b5946356095738cb90a6df7b35ff69ac5750f6e783d5fbcc5cb3b6cbd7/etils-1.13.0-py3-none-any.whl", hash = "sha256:d9cd4f40fbe77ad6613b7348a18132cc511237b6c076dbb89105c0b520a4c6bb", size = 170603, upload-time = "2025-07-15T10:29:09.076Z" },
+]
+
+[package.optional-dependencies]
+epath = [
+    { name = "fsspec" },
+    { name = "importlib-resources" },
+    { name = "typing-extensions" },
+    { name = "zipp" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -889,6 +915,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b9/b1/f5a13cdc05b9a16502d760ead310a689a1538f3fee9618b92011200b9717/fancy_einsum-0.0.3.tar.gz", hash = "sha256:05ca6689999d0949bdaa5320c81117effa13644ec68a200121e93d7ebf3d3356", size = 4916, upload-time = "2022-02-04T01:53:46.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/14/26fc262ba70976eea9a42e67b05c67aa78a0ee38332d9d094cca5d2c5ec3/fancy_einsum-0.0.3-py3-none-any.whl", hash = "sha256:e0bf33587a61822b0668512ada237a0ffa5662adfb9acfcbb0356ee15a0396a1", size = 6239, upload-time = "2022-02-04T01:53:44.44Z" },
+]
+
+[[package]]
+name = "farama-notifications"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/2c/8384832b7a6b1fd6ba95bbdcae26e7137bb3eedc955c42fd5cdcc086cfbf/Farama-Notifications-0.0.4.tar.gz", hash = "sha256:13fceff2d14314cf80703c8266462ebf3733c7d165336eee998fc58e545efd18", size = 2131, upload-time = "2023-02-27T18:28:41.047Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/2c/ffc08c54c05cdce6fbed2aeebc46348dbe180c6d2c541c7af7ba0aa5f5f8/Farama_Notifications-0.0.4-py3-none-any.whl", hash = "sha256:14de931035a41961f7c056361dc7f980762a143d05791ef5794a751a2caf05ae", size = 2511, upload-time = "2023-02-27T18:28:39.447Z" },
 ]
 
 [[package]]
@@ -1083,6 +1118,44 @@ wheels = [
 ]
 
 [[package]]
+name = "glfw"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/97/a2d667c98b8474f6b8294042488c1bd488681fb3cb4c3b9cdac1a9114287/glfw-2.9.0.tar.gz", hash = "sha256:077111a150ff09bc302c5e4ae265a5eb6aeaff0c8b01f727f7fb34e3764bb8e2", size = 31453, upload-time = "2025-04-15T15:39:54.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/71/13dd8a8d547809543d21de9438a3a76a8728fc7966d01ad9fb54599aebf5/glfw-2.9.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-macosx_10_6_intel.whl", hash = "sha256:183da99152f63469e9263146db2eb1b6cc4ee0c4082b280743e57bd1b0a3bd70", size = 105297, upload-time = "2025-04-15T15:39:39.677Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/a2/45e6dceec1e0a0ffa8dd3c0ecf1e11d74639a55186243129160c6434d456/glfw-2.9.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-macosx_11_0_arm64.whl", hash = "sha256:aef5b555673b9555216e4cd7bc0bdbbb9983f66c620a85ba7310cfcfda5cd38c", size = 102146, upload-time = "2025-04-15T15:39:42.354Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/72/b6261ed918e3747c6070fe80636c63a3c8f1c42ce122670315eeeada156f/glfw-2.9.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-manylinux2014_aarch64.whl", hash = "sha256:fcc430cb21984afba74945b7df38a5e1a02b36c0b4a2a2bab42b4a26d7cc51d6", size = 230002, upload-time = "2025-04-15T15:39:43.933Z" },
+    { url = "https://files.pythonhosted.org/packages/45/d6/7f95786332e8b798569b8e60db2ee081874cec2a62572b8ec55c309d85b7/glfw-2.9.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-manylinux2014_x86_64.whl", hash = "sha256:7f85b58546880466ac445fc564c5c831ca93c8a99795ab8eaf0a2d521af293d7", size = 241949, upload-time = "2025-04-15T15:39:45.28Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e6/093ab7874a74bba351e754f6e7748c031bd7276702135da6cbcd00e1f3e2/glfw-2.9.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-manylinux_2_28_aarch64.whl", hash = "sha256:2123716c8086b80b797e849a534fc6f21aebca300519e57c80618a65ca8135dc", size = 231016, upload-time = "2025-04-15T15:39:46.669Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ba/de3630757c7d7fc2086aaf3994926d6b869d31586e4d0c14f1666af31b93/glfw-2.9.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-manylinux_2_28_x86_64.whl", hash = "sha256:4e11271e49eb9bc53431ade022e284d5a59abeace81fe3b178db1bf3ccc0c449", size = 243489, upload-time = "2025-04-15T15:39:48.321Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/c3bada8503681806231d1705ea1802bac8febf69e4186b9f0f0b9e2e4f7e/glfw-2.9.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-win32.whl", hash = "sha256:8e4fbff88e4e953bb969b6813195d5de4641f886530cc8083897e56b00bf2c8e", size = 552655, upload-time = "2025-04-15T15:39:50.029Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/70/7f2f052ca20c3b69892818f2ee1fea53b037ea9145ff75b944ed1dc4ff82/glfw-2.9.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-win_amd64.whl", hash = "sha256:9aa3ae51601601c53838315bd2a03efb1e6bebecd072b2f64ddbd0b2556d511a", size = 559441, upload-time = "2025-04-15T15:39:52.531Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/17/c2a0e15c2cd5a8e788389b280996db927b923410de676ec5c7b2695e9261/gymnasium-1.2.0.tar.gz", hash = "sha256:344e87561012558f603880baf264ebc97f8a5c997a957b0c9f910281145534b0", size = 821142, upload-time = "2025-06-27T08:21:20.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/e2/a111dbb8625af467ea4760a1373d6ef27aac3137931219902406ccc05423/gymnasium-1.2.0-py3-none-any.whl", hash = "sha256:fc4a1e4121a9464c29b4d7dc6ade3fbeaa36dea448682f5f71a6d2c17489ea76", size = 944301, upload-time = "2025-06-27T08:21:18.83Z" },
+]
+
+[package.optional-dependencies]
+mujoco = [
+    { name = "imageio" },
+    { name = "mujoco" },
+    { name = "packaging" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1144,6 +1217,19 @@ wheels = [
 ]
 
 [[package]]
+name = "imageio"
+version = "2.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/47/57e897fb7094afb2d26e8b2e4af9a45c7cf1a405acdeeca001fdf2c98501/imageio-2.37.0.tar.gz", hash = "sha256:71b57b3669666272c818497aebba2b4c5f20d5b37c81720e5e1a56d59c492996", size = 389963, upload-time = "2025-01-20T02:42:37.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/bd/b394387b598ed84d8d0fa90611a90bee0adc2021820ad5729f7ced74a8e2/imageio-2.37.0-py3-none-any.whl", hash = "sha256:11efa15b87bc7871b61590326b2d635439acc321cf7f8ce996f812543ce10eed", size = 315796, upload-time = "2025-01-20T02:42:34.931Z" },
+]
+
+[[package]]
 name = "imagesize"
 version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1162,6 +1248,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
+]
+
+[[package]]
+name = "importlib-resources"
+version = "6.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693, upload-time = "2025-01-03T18:51:56.698Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ed/1f1afb2e9e7f38a545d628f864d562a5ae64fe6f7a10e28ffb9b185b4e89/importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec", size = 37461, upload-time = "2025-01-03T18:51:54.306Z" },
 ]
 
 [[package]]
@@ -1708,6 +1803,41 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/53/2f/2b1c2b056894fbaa975f68f81e3014bb447516a8b010f1bed3fb0e016ed7/msgspec-0.19.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac7f7c377c122b649f7545810c6cd1b47586e3aa3059126ce3516ac7ccc6a6a9", size = 213996, upload-time = "2024-12-27T17:40:12.244Z" },
     { url = "https://files.pythonhosted.org/packages/aa/5a/4cd408d90d1417e8d2ce6a22b98a6853c1b4d7cb7669153e4424d60087f6/msgspec-0.19.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a5bc1472223a643f5ffb5bf46ccdede7f9795078194f14edd69e3aab7020d327", size = 219087, upload-time = "2024-12-27T17:40:14.881Z" },
     { url = "https://files.pythonhosted.org/packages/23/d8/f15b40611c2d5753d1abb0ca0da0c75348daf1252220e5dda2867bd81062/msgspec-0.19.0-cp313-cp313-win_amd64.whl", hash = "sha256:317050bc0f7739cb30d257ff09152ca309bf5a369854bbf1e57dffc310c1f20f", size = 187432, upload-time = "2024-12-27T17:40:16.256Z" },
+]
+
+[[package]]
+name = "mujoco"
+version = "3.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "etils", extra = ["epath"] },
+    { name = "glfw" },
+    { name = "numpy" },
+    { name = "pyopengl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/43/38e9d1d3ff9ee75e6deb57840ccbe8a6eb8364a9b869fde07e686878db50/mujoco-3.3.5.tar.gz", hash = "sha256:f9fc6550fc9ed9768223db2d7b3cc32b5a02eb9e887282b40e451c266af16a46", size = 813883, upload-time = "2025-08-08T22:52:29.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/0f/5baccddb861dee44437530de058f992e40452ff884a58675ed18b4c7ac10/mujoco-3.3.5-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:e2b161d172a9aa41e53a837d52b756d41ca97d69ca694fdbb6fea090e387b79c", size = 6372190, upload-time = "2025-08-08T22:51:28.01Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/30/00946cb6a6e6b2b3235cdee5881f863a49f738e775761b5edff161b2a4c1/mujoco-3.3.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:26f2576c55e6a7eae9ac348beb9af310ae55e0f570e5a1bc4dff2c254c0c28e4", size = 6574705, upload-time = "2025-08-08T22:51:31.084Z" },
+    { url = "https://files.pythonhosted.org/packages/23/cb/cceaa0bc6fffacbf66ba10b61ced943459ed32c652abcde39c3c549a17e5/mujoco-3.3.5-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e304f33404d0421a2e65651dd171846f7c2a8c8b8120272eedd727a6f53ed073", size = 6248496, upload-time = "2025-08-08T22:51:33.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/aa/335588e864632048a6091a3a060a3d490549dc4e57ad5317415c51cef6e3/mujoco-3.3.5-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9be402d36db82a7efef4b6b2553590b288e1ceed593d648fff58f75aa89a501a", size = 6627254, upload-time = "2025-08-08T22:51:36.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/fd/5ab4dc6cf53490e9ae2c3e8e27150f1432e855aed69ac9983aff260e912f/mujoco-3.3.5-cp310-cp310-win_amd64.whl", hash = "sha256:f392b21655a8ae466e0677696bb311527847e4cbce5ebe1023e637b6d41e0acc", size = 5163714, upload-time = "2025-08-08T22:51:39.061Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/56/111b2a39b1e24605a1ca544332367c63b1bde79c2d75101cdfda1fb4c66a/mujoco-3.3.5-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:c2e315c80d0f1fbaa8ebf48d00c48bd1f228a0d9f77edeafbc6935b2c65fc7af", size = 6386014, upload-time = "2025-08-08T22:51:41.338Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/32/0f51e8ebdd75602430e6f6057ab589481deb6ad073fd2b167da95d0ae2d3/mujoco-3.3.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:aa4bf4b083e1da6e3df0d35b5e1c8a32718946b973de07eb23aa0166e6c4ea67", size = 6586940, upload-time = "2025-08-08T22:51:43.901Z" },
+    { url = "https://files.pythonhosted.org/packages/67/2f/c6c056584fe8074a0f1dd17d243b6e07842ce9c8b419c60aa61ee76e6c7f/mujoco-3.3.5-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:595e2dcbb2e17eef4302cf9b05cee02221d5487989729c6fe836ec52c7135cad", size = 6263801, upload-time = "2025-08-08T22:51:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/40/c7/0752bf8236e159328a91a8b4db10b4b5f2d863236611f2930adac35fb227/mujoco-3.3.5-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cc88d9459f0197f7a881a9d517af2af66e856e564362013a8dae4000860b32b4", size = 6641950, upload-time = "2025-08-08T22:51:48.976Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/af/9d0a163fe346e3860425c81008b48476232eec1106f52d4a305223dc930c/mujoco-3.3.5-cp311-cp311-win_amd64.whl", hash = "sha256:66d455f3922a57a475bde42921812369536a50dbe89b7649dad2d48e93656b97", size = 5188702, upload-time = "2025-08-08T22:51:53.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3c/9559fa21ad737c87ed15aecf45a3c0aa2b5b695ea9683472a957d628e812/mujoco-3.3.5-cp312-cp312-macosx_10_16_x86_64.whl", hash = "sha256:53f4b7ce0b69ae405b79f3bfd5c84b8a89535b1fe3e5b18c5a12c160a8b61374", size = 6493971, upload-time = "2025-08-08T22:51:55.218Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/7f/aa28c64d0ba3c7a4be4e11dd233700575a839467028a06289c7e75689167/mujoco-3.3.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f9e6aeb013512e0f1fc3a0692f032918ce55d97622c517b5c74246ac44ca542b", size = 6511657, upload-time = "2025-08-08T22:51:57.233Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/af/12e8a20695ec3b89bcf83f48d0608d4e5155710c8eafb9eede24764dd77b/mujoco-3.3.5-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:157ee984f4fea342cd2090a02891165130f8df4d607cc728c6cd32ff02f21710", size = 6280373, upload-time = "2025-08-08T22:51:59.834Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/87/f5454b3e3844bb5c37037a4f3e5e6e70a37263f06d34c2a5b62e801a5b3f/mujoco-3.3.5-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:802101bd705cb46973e2a0bc70e0d0d3581a2f6f764678bc6aa5253539ff341d", size = 6710089, upload-time = "2025-08-08T22:52:02.654Z" },
+    { url = "https://files.pythonhosted.org/packages/39/a0/e3fcb69401a15168d166eb44bde7820c1ed1b4cd27f36e6f78186a66d965/mujoco-3.3.5-cp312-cp312-win_amd64.whl", hash = "sha256:e793302c27a3aebb1d50714358b09d49af4c2f6633376a653bf0df700470c2ba", size = 5249580, upload-time = "2025-08-08T22:52:04.691Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/84/c858e06b87cffcb36b854852dfb55f9dbef1e206570e6566abc9b58300fb/mujoco-3.3.5-cp313-cp313-macosx_10_16_x86_64.whl", hash = "sha256:aed797980fbc622bc2ca86201b13098948bae6ec12f8b129310df73a43c8a178", size = 6494134, upload-time = "2025-08-08T22:52:06.715Z" },
+    { url = "https://files.pythonhosted.org/packages/96/9f/709d3ef825722ddbcc5774e7f7bbc819f844541d8a9fec96a92fe625bace/mujoco-3.3.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3c8be5deecfe16e08d2ebb5f68cac947b97c736044e81717327516c05355fe29", size = 6511318, upload-time = "2025-08-08T22:52:08.702Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ad/0552ec5b143bc97b61fbc84661215f12a76da4b3efb7dc98be04ba040bc7/mujoco-3.3.5-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23e9bc7fdec763fe2cba7e013d02d692b3f25d0e32baf91d664e09c4a0b2e803", size = 6280451, upload-time = "2025-08-08T22:52:11.219Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/8c/54e5dd1df6fced73ea0b183ccf05939757bfc6fab9d720e1e051963ae154/mujoco-3.3.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70ef62e02169e74d7dd38e8eacc5275d9d1f53eb0713fd410fe1d71410ecfd93", size = 6710285, upload-time = "2025-08-08T22:52:13.641Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/47/34c90be2665e64ff54bcd003c8c5051337ea7652e1c28f2901b1f4c796d9/mujoco-3.3.5-cp313-cp313-win_amd64.whl", hash = "sha256:6f068d5c68ffe28b8bbd9857a5c681261bf6e924eb52d2efdfc2cd7a66b35d27", size = 5250233, upload-time = "2025-08-08T22:52:15.527Z" },
 ]
 
 [[package]]
@@ -2877,6 +3007,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyopengl"
+version = "3.1.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/42/71080db298df3ddb7e3090bfea8fd7c300894d8b10954c22f8719bd434eb/pyopengl-3.1.9.tar.gz", hash = "sha256:28ebd82c5f4491a418aeca9672dffb3adbe7d33b39eada4548a5b4e8c03f60c8", size = 1913642, upload-time = "2025-01-20T02:17:53.263Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/44/8634af40b0db528b5b37e901c0dc67321354880d251bf8965901d57693a5/PyOpenGL-3.1.9-py3-none-any.whl", hash = "sha256:15995fd3b0deb991376805da36137a4ae5aba6ddbb5e29ac1f35462d130a3f77", size = 3190341, upload-time = "2025-01-20T02:17:50.913Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3913,6 +4052,7 @@ notebooks = [
 ]
 scripts = [
     { name = "captum" },
+    { name = "gymnasium", extra = ["mujoco"] },
     { name = "lczerolens" },
     { name = "loguru" },
     { name = "matplotlib" },
@@ -3920,6 +4060,7 @@ scripts = [
     { name = "numpy" },
     { name = "pyside6" },
     { name = "scikit-learn" },
+    { name = "torchrl" },
     { name = "transformer-lens" },
     { name = "zennit", version = "0.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11.11'" },
     { name = "zennit", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11.11'" },
@@ -3954,6 +4095,7 @@ docs = [
 notebooks = [{ name = "ipykernel", specifier = ">=6.29.5" }]
 scripts = [
     { name = "captum", specifier = ">=0.8.0" },
+    { name = "gymnasium", extras = ["mujoco"], specifier = ">=1.2.0" },
     { name = "lczerolens", git = "https://github.com/Xmaster6y/lczerolens?branch=chores" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "matplotlib", specifier = ">=3.8.0" },
@@ -3961,6 +4103,7 @@ scripts = [
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "pyside6", specifier = ">=6.9.1" },
     { name = "scikit-learn", specifier = ">=1.7.1" },
+    { name = "torchrl", specifier = ">=0.9.2" },
     { name = "transformer-lens", specifier = ">=2.15.4" },
     { name = "zennit", specifier = ">=0.5.1" },
 ]
@@ -4145,6 +4288,40 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/90/1c/48b988870823d1cc381f15ec4e70ed3d65e043f43f919329b0045ae83529/torch-2.7.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:30207f672328a42df4f2174b8f426f354b2baa0b7cca3a0adb3d6ab5daf00dc8", size = 821098066, upload-time = "2025-06-04T17:37:33.939Z" },
     { url = "https://files.pythonhosted.org/packages/7b/eb/10050d61c9d5140c5dc04a89ed3257ef1a6b93e49dd91b95363d757071e0/torch-2.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:79042feca1c634aaf6603fe6feea8c6b30dfa140a6bbc0b973e2260c7e79a22e", size = 216336310, upload-time = "2025-06-04T17:36:09.862Z" },
     { url = "https://files.pythonhosted.org/packages/b1/29/beb45cdf5c4fc3ebe282bf5eafc8dfd925ead7299b3c97491900fe5ed844/torch-2.7.1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:988b0cbc4333618a1056d2ebad9eb10089637b659eb645434d0809d8d937b946", size = 68645708, upload-time = "2025-06-04T17:34:39.852Z" },
+]
+
+[[package]]
+name = "torchrl"
+version = "0.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "tensordict" },
+    { name = "torch" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/fe/fe15e7ddbb050c94ae195f7ebf301fcd59731a2d396b6650502e194e6cba/torchrl-0.9.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8a37d08ffac866832c77a71f7e8afdc4a354c8f729a471a2400ff2cea02af632", size = 1714742, upload-time = "2025-07-17T17:06:56.937Z" },
+    { url = "https://files.pythonhosted.org/packages/97/df/b3e8de956945a2b58e9c80d868becd308b81c38ac79594991cfad376f762/torchrl-0.9.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:d7969a9394d7a3d5d35bda18d23aeb10981f08b46eced0cdee976c145c6194b3", size = 1402892, upload-time = "2025-07-17T17:06:58.576Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/3a/23c52c98ecc40f1fbf6ffd48ed95f6027c933374886451fe7be421fbf43f/torchrl-0.9.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:08c772e113e085737fb956e2b69390ac1ea38924533e61b3c717e829024040cd", size = 1409679, upload-time = "2025-07-17T17:07:00.002Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/81/da6bdaf56aae725f6722d84f92e39b8aca86fc6c70c55d003e6891ea9130/torchrl-0.9.2-cp310-cp310-win_amd64.whl", hash = "sha256:1aeb1a60736be00959644c2ce7c1a9d402c612bcef240574fd0905092173976f", size = 1370446, upload-time = "2025-07-17T17:07:01.174Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/583b8a4c55abd6e4945e4787f3b6a44214abc8ca1c50d82102e9473645da/torchrl-0.9.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:76b7ed6918cfdfeaf65a498df3ceca6b814960377860f77211216989ef30a31e", size = 1715997, upload-time = "2025-07-17T17:07:02.744Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/4d/ea265e1ad4875b42c8a797ebe8ba48987899b6b2298d0f28e3b080f68cd9/torchrl-0.9.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:a2e2f7392d8350f1eed048420c6b8d361d85d1ddd93974ca1ffd1a6def51516e", size = 1404579, upload-time = "2025-07-17T17:07:04.505Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/87/66b126cfe7dce7f31f5e638475a9ebc9e744d5f083d49ebc558178b9d57f/torchrl-0.9.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:18ada5d4676f45db66b99a8de37a5780a4b7be227124d42257eae1ee74ff7fa8", size = 1411513, upload-time = "2025-07-17T17:07:05.951Z" },
+    { url = "https://files.pythonhosted.org/packages/df/05/38b1360d794663204a6622e0f9ba2fc5846821f47a9c6a1cb761717a0dd5/torchrl-0.9.2-cp311-cp311-win_amd64.whl", hash = "sha256:93ca8d378244480b5f268725c08090e381f94a665129ed22e3c9a771d03de69f", size = 1371515, upload-time = "2025-07-17T17:07:07.092Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0c/2c4bc554eccd8601b94eeddaf123d78f6c4e2cffc8af4bc2258be436faaf/torchrl-0.9.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:30dff9165d117b9f67bfff9466b8271d25bbfa14231eb41d9faed407db35a8d8", size = 1718618, upload-time = "2025-07-17T17:07:08.204Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/32/4aa545fb408d47f3ae8f1b44b93f1dcddfa534fb209f9f83a9168ffb22cf/torchrl-0.9.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:81a236ad797b82a12f8e64ca774ea5b0ea87e9083a6f38268625993ea0a3c122", size = 1404089, upload-time = "2025-07-17T17:07:09.688Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/9e/0657833e90aa23ecd7ec18ddf9942bbd298f91bf4fe1fe49988a647d614c/torchrl-0.9.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:3ac51734e3a75961e80167f3945848325c3186edbda119dd6e3cb403def1584d", size = 1410004, upload-time = "2025-07-17T17:07:10.777Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/36bda622004c182f56ef736f386d362166e5776bdf4d1992fc7aa9cc007b/torchrl-0.9.2-cp312-cp312-win_amd64.whl", hash = "sha256:5da161795521fd1bc71dc09075fb9f185700018c2296f0889d514f0f12a4d21d", size = 1372046, upload-time = "2025-07-17T17:07:11.91Z" },
+    { url = "https://files.pythonhosted.org/packages/87/84/0499ce67a8bd1b30089af16c106ddd8c69cd553b2d1a30408368388b13c3/torchrl-0.9.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9a1ffe1d2f454b694524e5f32558a58a10919da87a104561c6ccd087398644a6", size = 1718747, upload-time = "2025-07-17T17:07:13.417Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f5/29498644927b1f9146761f4f3ad35fa6959af16e41ee526a143133925a8b/torchrl-0.9.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:bcce03361f38869d864def752af6bab86010eeb60bedb73f480504e055fe5223", size = 1403877, upload-time = "2025-07-17T17:07:15.126Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/cc/a63cd1c00ecb96393ab270bcc3f6cad2cdaa67846aebc67e8c515350230e/torchrl-0.9.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6610422d448af96160362775449ad22453a76d9f5ef15f2607ed185e63ee59ca", size = 1410651, upload-time = "2025-07-17T17:07:16.229Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f5/c365e738709057c8d297ec06104fca4793e860e3c7acad63babe422cf344/torchrl-0.9.2-cp313-cp313-win_amd64.whl", hash = "sha256:6c91e6b1fef31f3d20408126904b2202f1d37cb4ba3d39fcac66830c37d13a14", size = 1372038, upload-time = "2025-07-17T17:07:17.367Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e6/6a30ade56e33da16a3c7ae22e1018269da8a10a32e3f9b7399f11f57a06d/torchrl-0.9.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8eeb0571cca8ac76eb2b818d5ed47b10e746de306af9e5c52c0bb0ebdfc80163", size = 1773110, upload-time = "2025-07-17T17:07:18.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e7/f798526cf38344d53e539e24de75616e814f0a9edff85faa921cb9d71b4f/torchrl-0.9.2-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:717c6631c74ef9f65801089eaf11a946d800794ab66dbeba73a8a17f9a689a2d", size = 1402524, upload-time = "2025-07-17T17:07:19.854Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/42/d316f7c4c9021cf96bcca8b6b09dd77edb17a99967e4540f153156dcf454/torchrl-0.9.2-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ae4ab524c795227ecfab8703fe2a5148558bca621e2bb9f3ecc017f456de6f2e", size = 1411016, upload-time = "2025-07-17T17:07:20.98Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/1a/8548715958204306a39f7e4fa53aa00f9112a1217d8a59a255d39e6e3a78/torchrl-0.9.2-cp313-cp313t-win_amd64.whl", hash = "sha256:5fafde3cec493025946c2ef61c80ce6b5949fbbadd93393a2c9b589152683fd3", size = 1386871, upload-time = "2025-07-17T17:07:22.4Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'linux'",
@@ -435,6 +435,12 @@ wheels = [
 ]
 
 [[package]]
+name = "chess"
+version = "1.11.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/09/7d04d7581ae3bb8b598017941781bceb7959dd1b13e3ebf7b6a2cd843bc9/chess-1.11.2.tar.gz", hash = "sha256:a8b43e5678fdb3000695bdaa573117ad683761e5ca38e591c4826eba6d25bb39", size = 6131385, upload-time = "2025-02-25T19:10:27.328Z" }
+
+[[package]]
 name = "click"
 version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -860,7 +866,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -1297,6 +1303,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/fe/0f5a938c54105553436dbff7a61dc4fed4b1b2c98852f8833beaf4d5968f/joblib-1.5.1.tar.gz", hash = "sha256:f4f86e351f39fe3d0d32a9f2c3d8af1ee4cec285aafcb27003dda5205576b444", size = 330475, upload-time = "2025-05-23T12:04:37.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/4f/1195bbac8e0c2acc5f740661631d8d750dc38d4a32b23ee5df3cde6f4e0d/joblib-1.5.1-py3-none-any.whl", hash = "sha256:4719a31f054c7d766948dcd83e9613686b27114f190f717cec7eaa2084f8a74a", size = 307746, upload-time = "2025-05-23T12:04:35.124Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1447,6 +1462,17 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/eb/78d50346c51db22c7203c1611f9b513075f35c4e0e4877c5dde378d66043/kiwisolver-1.4.8-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7cd2785b9391f2873ad46088ed7599a6a71e762e1ea33e87514b1a441ed1da1c", size = 81186, upload-time = "2024-12-24T18:30:45.654Z" },
     { url = "https://files.pythonhosted.org/packages/43/f8/7259f18c77adca88d5f64f9a522792e178b2691f3748817a8750c2d216ef/kiwisolver-1.4.8-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c07b29089b7ba090b6f1a669f1411f27221c3662b3a1b7010e67b59bb5a6f10b", size = 80279, upload-time = "2024-12-24T18:30:47.951Z" },
     { url = "https://files.pythonhosted.org/packages/3a/1d/50ad811d1c5dae091e4cf046beba925bcae0a610e79ae4c538f996f63ed5/kiwisolver-1.4.8-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:65ea09a5a3faadd59c2ce96dc7bf0f364986a315949dc6374f04396b0d60e09b", size = 71762, upload-time = "2024-12-24T18:30:48.903Z" },
+]
+
+[[package]]
+name = "lczerolens"
+version = "0.3.3.dev0"
+source = { git = "https://github.com/Xmaster6y/lczerolens?branch=chores#0f8ea1fccd68118d131c79ab67dec7980e9237a8" }
+dependencies = [
+    { name = "onnx2torch" },
+    { name = "python-chess" },
+    { name = "tensordict" },
+    { name = "torch" },
 ]
 
 [[package]]
@@ -2030,7 +2056,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.5.1.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/78/4535c9c7f859a64781e43c969a3a7e84c54634e319a996d43ef32ce46f83/nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:30ac3869f6db17d170e0e556dd6cc5eee02647abc31ca856634d5a40f82c15b2", size = 570988386, upload-time = "2024-10-25T19:54:26.39Z" },
@@ -2041,7 +2067,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/16/73727675941ab8e6ffd86ca3a4b7b47065edcca7a997920b831f8147c99d/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ccba62eb9cef5559abd5e0d54ceed2d9934030f51163df018532142a8ec533e5", size = 200221632, upload-time = "2024-11-20T17:41:32.357Z" },
@@ -2070,9 +2096,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/6e/c2cf12c9ff8b872e92b4a5740701e51ff17689c4d726fca91875b07f655d/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9e49843a7707e42022babb9bcfa33c29857a93b88020c4e4434656a655b698c", size = 158229790, upload-time = "2024-11-20T17:43:43.211Z" },
@@ -2084,7 +2110,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/1e/b8b7c2f4099a37b96af5c9bb158632ea9e5d9d27d7391d7eb8fc45236674/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7556d9eca156e18184b94947ade0fba5bb47d69cec46bf8660fd2c71a4b48b73", size = 216561367, upload-time = "2024-11-20T17:44:54.824Z" },
@@ -2122,6 +2148,59 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/9a/fff8376f8e3d084cd1530e1ef7b879bb7d6d265620c95c1b322725c694f4/nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b90bed3df379fa79afbd21be8e04a0314336b8ae16768b58f2d34cb1d04cd7d2", size = 89276, upload-time = "2024-11-20T17:38:27.621Z" },
     { url = "https://files.pythonhosted.org/packages/9e/4e/0d0c945463719429b7bd21dece907ad0bde437a2ff12b9b12fee94722ab0/nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:6574241a3ec5fdc9334353ab8c479fe75841dbe8f4532a8fc97ce63503330ba1", size = 89265, upload-time = "2024-10-01T17:00:38.172Z" },
+]
+
+[[package]]
+name = "onnx"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/60/e56e8ec44ed34006e6d4a73c92a04d9eea6163cc12440e35045aec069175/onnx-1.18.0.tar.gz", hash = "sha256:3d8dbf9e996629131ba3aa1afd1d8239b660d1f830c6688dd7e03157cccd6b9c", size = 12563009, upload-time = "2025-05-12T22:03:09.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/e3/ab8a09c0af43373e0422de461956a1737581325260659aeffae22a7dad18/onnx-1.18.0-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:4a3b50d94620e2c7c1404d1d59bc53e665883ae3fecbd856cc86da0639fd0fc3", size = 18280145, upload-time = "2025-05-12T22:01:49.875Z" },
+    { url = "https://files.pythonhosted.org/packages/04/5b/3cfd183961a0a872fe29c95f8d07264890ec65c75c94b99a4dabc950df29/onnx-1.18.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e189652dad6e70a0465035c55cc565c27aa38803dd4f4e74e4b952ee1c2de94b", size = 17422721, upload-time = "2025-05-12T22:01:52.841Z" },
+    { url = "https://files.pythonhosted.org/packages/58/52/fa649429016c5790f68c614cdebfbefd3e72ba1c458966305297d540f713/onnx-1.18.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfb1f271b1523b29f324bfd223f6a4cfbdc5a2f2f16e73563671932d33663365", size = 17584220, upload-time = "2025-05-12T22:01:56.458Z" },
+    { url = "https://files.pythonhosted.org/packages/42/52/dc166de41a5f72738b0bdfb2a19e0ebe4743cf3ecc9ae381ea3425bcb332/onnx-1.18.0-cp310-cp310-win32.whl", hash = "sha256:e03071041efd82e0317b3c45433b2f28146385b80f26f82039bc68048ac1a7a0", size = 15734494, upload-time = "2025-05-12T22:01:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/f9/e766a3b85b7651ddfc5f9648e0e9dc24e88b7e88ea7f8c23187530e818ea/onnx-1.18.0-cp310-cp310-win_amd64.whl", hash = "sha256:9235b3493951e11e75465d56f4cd97e3e9247f096160dd3466bfabe4cbc938bc", size = 15848421, upload-time = "2025-05-12T22:02:03.01Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/3a/a336dac4db1eddba2bf577191e5b7d3e4c26fcee5ec518a5a5b11d13540d/onnx-1.18.0-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:735e06d8d0cf250dc498f54038831401063c655a8d6e5975b2527a4e7d24be3e", size = 18281831, upload-time = "2025-05-12T22:02:06.429Z" },
+    { url = "https://files.pythonhosted.org/packages/02/3a/56475a111120d1e5d11939acbcbb17c92198c8e64a205cd68e00bdfd8a1f/onnx-1.18.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:73160799472e1a86083f786fecdf864cf43d55325492a9b5a1cfa64d8a523ecc", size = 17424359, upload-time = "2025-05-12T22:02:09.866Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/03/5eb5e9ef446ed9e78c4627faf3c1bc25e0f707116dd00e9811de232a8df5/onnx-1.18.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6acafb3823238bbe8f4340c7ac32fb218689442e074d797bee1c5c9a02fdae75", size = 17586006, upload-time = "2025-05-12T22:02:13.217Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4e/70943125729ce453271a6e46bb847b4a612496f64db6cbc6cb1f49f41ce1/onnx-1.18.0-cp311-cp311-win32.whl", hash = "sha256:4c8c4bbda760c654e65eaffddb1a7de71ec02e60092d33f9000521f897c99be9", size = 15734988, upload-time = "2025-05-12T22:02:16.561Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b0/435fd764011911e8f599e3361f0f33425b1004662c1ea33a0ad22e43db2d/onnx-1.18.0-cp311-cp311-win_amd64.whl", hash = "sha256:a5810194f0f6be2e58c8d6dedc6119510df7a14280dd07ed5f0f0a85bd74816a", size = 15849576, upload-time = "2025-05-12T22:02:19.569Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/f0/9e31f4b4626d60f1c034f71b411810bc9fafe31f4e7dd3598effd1b50e05/onnx-1.18.0-cp311-cp311-win_arm64.whl", hash = "sha256:aa1b7483fac6cdec26922174fc4433f8f5c2f239b1133c5625063bb3b35957d0", size = 15822961, upload-time = "2025-05-12T22:02:22.735Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/fe/16228aca685392a7114625b89aae98b2dc4058a47f0f467a376745efe8d0/onnx-1.18.0-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:521bac578448667cbb37c50bf05b53c301243ede8233029555239930996a625b", size = 18285770, upload-time = "2025-05-12T22:02:26.116Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/77/ba50a903a9b5e6f9be0fa50f59eb2fca4a26ee653375408fbc72c3acbf9f/onnx-1.18.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4da451bf1c5ae381f32d430004a89f0405bc57a8471b0bddb6325a5b334aa40", size = 17421291, upload-time = "2025-05-12T22:02:29.645Z" },
+    { url = "https://files.pythonhosted.org/packages/11/23/25ec2ba723ac62b99e8fed6d7b59094dadb15e38d4c007331cc9ae3dfa5f/onnx-1.18.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99afac90b4cdb1471432203c3c1f74e16549c526df27056d39f41a9a47cfb4af", size = 17584084, upload-time = "2025-05-12T22:02:32.789Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/4d/2c253a36070fb43f340ff1d2c450df6a9ef50b938adcd105693fee43c4ee/onnx-1.18.0-cp312-cp312-win32.whl", hash = "sha256:ee159b41a3ae58d9c7341cf432fc74b96aaf50bd7bb1160029f657b40dc69715", size = 15734892, upload-time = "2025-05-12T22:02:35.527Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/92/048ba8fafe6b2b9a268ec2fb80def7e66c0b32ab2cae74de886981f05a27/onnx-1.18.0-cp312-cp312-win_amd64.whl", hash = "sha256:102c04edc76b16e9dfeda5a64c1fccd7d3d2913b1544750c01d38f1ac3c04e05", size = 15850336, upload-time = "2025-05-12T22:02:38.545Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/66/bbc4ffedd44165dcc407a51ea4c592802a5391ce3dc94aa5045350f64635/onnx-1.18.0-cp312-cp312-win_arm64.whl", hash = "sha256:911b37d724a5d97396f3c2ef9ea25361c55cbc9aa18d75b12a52b620b67145af", size = 15823802, upload-time = "2025-05-12T22:02:42.037Z" },
+    { url = "https://files.pythonhosted.org/packages/45/da/9fb8824513fae836239276870bfcc433fa2298d34ed282c3a47d3962561b/onnx-1.18.0-cp313-cp313-macosx_12_0_universal2.whl", hash = "sha256:030d9f5f878c5f4c0ff70a4545b90d7812cd6bfe511de2f3e469d3669c8cff95", size = 18285906, upload-time = "2025-05-12T22:02:45.01Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e8/762b5fb5ed1a2b8e9a4bc5e668c82723b1b789c23b74e6b5a3356731ae4e/onnx-1.18.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8521544987d713941ee1e591520044d35e702f73dc87e91e6d4b15a064ae813d", size = 17421486, upload-time = "2025-05-12T22:02:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/12/bb/471da68df0364f22296456c7f6becebe0a3da1ba435cdb371099f516da6e/onnx-1.18.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c137eecf6bc618c2f9398bcc381474b55c817237992b169dfe728e169549e8f", size = 17583581, upload-time = "2025-05-12T22:02:51.784Z" },
+    { url = "https://files.pythonhosted.org/packages/76/0d/01a95edc2cef6ad916e04e8e1267a9286f15b55c90cce5d3cdeb359d75d6/onnx-1.18.0-cp313-cp313-win32.whl", hash = "sha256:6c093ffc593e07f7e33862824eab9225f86aa189c048dd43ffde207d7041a55f", size = 15734621, upload-time = "2025-05-12T22:02:54.62Z" },
+    { url = "https://files.pythonhosted.org/packages/64/95/253451a751be32b6173a648b68f407188009afa45cd6388780c330ff5d5d/onnx-1.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:230b0fb615e5b798dc4a3718999ec1828360bc71274abd14f915135eab0255f1", size = 15850472, upload-time = "2025-05-12T22:02:57.54Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/b1/6fd41b026836df480a21687076e0f559bc3ceeac90f2be8c64b4a7a1f332/onnx-1.18.0-cp313-cp313-win_arm64.whl", hash = "sha256:6f91930c1a284135db0f891695a263fc876466bf2afbd2215834ac08f600cfca", size = 15823808, upload-time = "2025-05-12T22:03:00.305Z" },
+    { url = "https://files.pythonhosted.org/packages/70/f3/499e53dd41fa7302f914dd18543da01e0786a58b9a9d347497231192001f/onnx-1.18.0-cp313-cp313t-macosx_12_0_universal2.whl", hash = "sha256:2f4d37b0b5c96a873887652d1cbf3f3c70821b8c66302d84b0f0d89dd6e47653", size = 18316526, upload-time = "2025-05-12T22:03:03.691Z" },
+    { url = "https://files.pythonhosted.org/packages/84/dd/6abe5d7bd23f5ed3ade8352abf30dff1c7a9e97fc1b0a17b5d7c726e98a9/onnx-1.18.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a69afd0baa372162948b52c13f3aa2730123381edf926d7ef3f68ca7cec6d0d0", size = 15865055, upload-time = "2025-05-12T22:03:06.663Z" },
+]
+
+[[package]]
+name = "onnx2torch"
+version = "1.5.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "onnx" },
+    { name = "torch" },
+    { name = "torchvision" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/51/bb56a5dfee431aa61f13a297e33f6ae0654e55d3ba93d62b88b673182af3/onnx2torch-1.5.15.tar.gz", hash = "sha256:d2a239cf0871cbbeec13d43e2a72ac2f8b3c8dcf80695e4d1040c3deed2b14a2", size = 49786, upload-time = "2024-08-07T14:04:01.076Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/80/cec13a9bcb7525cbd941958037ccb5cd499e8466915130f3d2ee3772d34f/onnx2torch-1.5.15-py3-none-any.whl", hash = "sha256:123258e0f147e07b259cf845c8113c5634b8260e52c5fb26b7d507226732d9e5", size = 80965, upload-time = "2024-08-07T14:04:09.985Z" },
 ]
 
 [[package]]
@@ -2887,6 +2966,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-chess"
+version = "1.999"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/60/7c7d132b6683ff215bf705fc55ffc0240a6cddea89657407ca0a4fb628d0/python-chess-1.999.tar.gz", hash = "sha256:8cad0388c42242d890ac6368ad64def15cd0165db033df0ad479492e266e5e6c", size = 1453, upload-time = "2020-10-26T11:30:10.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/47/dfebc06e589530691d33c71bc7b3d8d311252b58ae338980fd4327fe77f2/python_chess-1.999-py3-none-any.whl", hash = "sha256:93b562f8f1124cb7bf56fb095e18743758e69dc6a028ccda0badcaa5c59d88c8", size = 1401, upload-time = "2020-10-26T11:30:07.758Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -3345,6 +3436,179 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/84/5f4af978fff619706b8961accac84780a6d298d82a8873446f72edb4ead0/scikit_learn-1.7.1.tar.gz", hash = "sha256:24b3f1e976a4665aa74ee0fcaac2b8fccc6ae77c8e07ab25da3ba6d3292b9802", size = 7190445, upload-time = "2025-07-18T08:01:54.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/88/0dd5be14ef19f2d80a77780be35a33aa94e8a3b3223d80bee8892a7832b4/scikit_learn-1.7.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:406204dd4004f0517f0b23cf4b28c6245cbd51ab1b6b78153bc784def214946d", size = 9338868, upload-time = "2025-07-18T08:01:00.25Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/52/3056b6adb1ac58a0bc335fc2ed2fcf599974d908855e8cb0ca55f797593c/scikit_learn-1.7.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:16af2e44164f05d04337fd1fc3ae7c4ea61fd9b0d527e22665346336920fe0e1", size = 8655943, upload-time = "2025-07-18T08:01:02.974Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a4/e488acdece6d413f370a9589a7193dac79cd486b2e418d3276d6ea0b9305/scikit_learn-1.7.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2f2e78e56a40c7587dea9a28dc4a49500fa2ead366869418c66f0fd75b80885c", size = 9652056, upload-time = "2025-07-18T08:01:04.978Z" },
+    { url = "https://files.pythonhosted.org/packages/18/41/bceacec1285b94eb9e4659b24db46c23346d7e22cf258d63419eb5dec6f7/scikit_learn-1.7.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b62b76ad408a821475b43b7bb90a9b1c9a4d8d125d505c2df0539f06d6e631b1", size = 9473691, upload-time = "2025-07-18T08:01:07.006Z" },
+    { url = "https://files.pythonhosted.org/packages/12/7b/e1ae4b7e1dd85c4ca2694ff9cc4a9690970fd6150d81b975e6c5c6f8ee7c/scikit_learn-1.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:9963b065677a4ce295e8ccdee80a1dd62b37249e667095039adcd5bce6e90deb", size = 8900873, upload-time = "2025-07-18T08:01:09.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/bd/a23177930abd81b96daffa30ef9c54ddbf544d3226b8788ce4c3ef1067b4/scikit_learn-1.7.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:90c8494ea23e24c0fb371afc474618c1019dc152ce4a10e4607e62196113851b", size = 9334838, upload-time = "2025-07-18T08:01:11.239Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a1/d3a7628630a711e2ac0d1a482910da174b629f44e7dd8cfcd6924a4ef81a/scikit_learn-1.7.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:bb870c0daf3bf3be145ec51df8ac84720d9972170786601039f024bf6d61a518", size = 8651241, upload-time = "2025-07-18T08:01:13.234Z" },
+    { url = "https://files.pythonhosted.org/packages/26/92/85ec172418f39474c1cd0221d611345d4f433fc4ee2fc68e01f524ccc4e4/scikit_learn-1.7.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:40daccd1b5623f39e8943ab39735cadf0bdce80e67cdca2adcb5426e987320a8", size = 9718677, upload-time = "2025-07-18T08:01:15.649Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ce/abdb1dcbb1d2b66168ec43b23ee0cee356b4cc4100ddee3943934ebf1480/scikit_learn-1.7.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30d1f413cfc0aa5a99132a554f1d80517563c34a9d3e7c118fde2d273c6fe0f7", size = 9511189, upload-time = "2025-07-18T08:01:18.013Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/3b/47b5eaee01ef2b5a80ba3f7f6ecf79587cb458690857d4777bfd77371c6f/scikit_learn-1.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:c711d652829a1805a95d7fe96654604a8f16eab5a9e9ad87b3e60173415cb650", size = 8914794, upload-time = "2025-07-18T08:01:20.357Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/16/57f176585b35ed865f51b04117947fe20f130f78940c6477b6d66279c9c2/scikit_learn-1.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3cee419b49b5bbae8796ecd690f97aa412ef1674410c23fc3257c6b8b85b8087", size = 9260431, upload-time = "2025-07-18T08:01:22.77Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4e/899317092f5efcab0e9bc929e3391341cec8fb0e816c4789686770024580/scikit_learn-1.7.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:2fd8b8d35817b0d9ebf0b576f7d5ffbbabdb55536b0655a8aaae629d7ffd2e1f", size = 8637191, upload-time = "2025-07-18T08:01:24.731Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1b/998312db6d361ded1dd56b457ada371a8d8d77ca2195a7d18fd8a1736f21/scikit_learn-1.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:588410fa19a96a69763202f1d6b7b91d5d7a5d73be36e189bc6396bfb355bd87", size = 9486346, upload-time = "2025-07-18T08:01:26.713Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/09/a2aa0b4e644e5c4ede7006748f24e72863ba2ae71897fecfd832afea01b4/scikit_learn-1.7.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e3142f0abe1ad1d1c31a2ae987621e41f6b578144a911ff4ac94781a583adad7", size = 9290988, upload-time = "2025-07-18T08:01:28.938Z" },
+    { url = "https://files.pythonhosted.org/packages/15/fa/c61a787e35f05f17fc10523f567677ec4eeee5f95aa4798dbbbcd9625617/scikit_learn-1.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:3ddd9092c1bd469acab337d87930067c87eac6bd544f8d5027430983f1e1ae88", size = 8735568, upload-time = "2025-07-18T08:01:30.936Z" },
+    { url = "https://files.pythonhosted.org/packages/52/f8/e0533303f318a0f37b88300d21f79b6ac067188d4824f1047a37214ab718/scikit_learn-1.7.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b7839687fa46d02e01035ad775982f2470be2668e13ddd151f0f55a5bf123bae", size = 9213143, upload-time = "2025-07-18T08:01:32.942Z" },
+    { url = "https://files.pythonhosted.org/packages/71/f3/f1df377d1bdfc3e3e2adc9c119c238b182293e6740df4cbeac6de2cc3e23/scikit_learn-1.7.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a10f276639195a96c86aa572ee0698ad64ee939a7b042060b98bd1930c261d10", size = 8591977, upload-time = "2025-07-18T08:01:34.967Z" },
+    { url = "https://files.pythonhosted.org/packages/99/72/c86a4cd867816350fe8dee13f30222340b9cd6b96173955819a5561810c5/scikit_learn-1.7.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:13679981fdaebc10cc4c13c43344416a86fcbc61449cb3e6517e1df9d12c8309", size = 9436142, upload-time = "2025-07-18T08:01:37.397Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/66/277967b29bd297538dc7a6ecfb1a7dce751beabd0d7f7a2233be7a4f7832/scikit_learn-1.7.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4f1262883c6a63f067a980a8cdd2d2e7f2513dddcef6a9eaada6416a7a7cbe43", size = 9282996, upload-time = "2025-07-18T08:01:39.721Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/47/9291cfa1db1dae9880420d1e07dbc7e8dd4a7cdbc42eaba22512e6bde958/scikit_learn-1.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:ca6d31fb10e04d50bfd2b50d66744729dbb512d4efd0223b864e2fdbfc4cee11", size = 8707418, upload-time = "2025-07-18T08:01:42.124Z" },
+    { url = "https://files.pythonhosted.org/packages/61/95/45726819beccdaa34d3362ea9b2ff9f2b5d3b8bf721bd632675870308ceb/scikit_learn-1.7.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:781674d096303cfe3d351ae6963ff7c958db61cde3421cd490e3a5a58f2a94ae", size = 9561466, upload-time = "2025-07-18T08:01:44.195Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/1c/6f4b3344805de783d20a51eb24d4c9ad4b11a7f75c1801e6ec6d777361fd/scikit_learn-1.7.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:10679f7f125fe7ecd5fad37dd1aa2daae7e3ad8df7f3eefa08901b8254b3e12c", size = 9040467, upload-time = "2025-07-18T08:01:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/80/abe18fe471af9f1d181904203d62697998b27d9b62124cd281d740ded2f9/scikit_learn-1.7.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1f812729e38c8cb37f760dce71a9b83ccfb04f59b3dca7c6079dcdc60544fa9e", size = 9532052, upload-time = "2025-07-18T08:01:48.676Z" },
+    { url = "https://files.pythonhosted.org/packages/14/82/b21aa1e0c4cee7e74864d3a5a721ab8fcae5ca55033cb6263dca297ed35b/scikit_learn-1.7.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88e1a20131cf741b84b89567e1717f27a2ced228e0f29103426102bc2e3b8ef7", size = 9361575, upload-time = "2025-07-18T08:01:50.639Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/f4777fcd5627dc6695fa6b92179d0edb7a3ac1b91bcd9a1c7f64fa7ade23/scikit_learn-1.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:b1bd1d919210b6a10b7554b717c9000b5485aa95a1d0f177ae0d7ee8ec750da5", size = 9277310, upload-time = "2025-07-18T08:01:52.547Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.15.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and sys_platform != 'linux'",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/2f/4966032c5f8cc7e6a60f1b2e0ad686293b9474b65246b0c642e3ef3badd0/scipy-1.15.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:a345928c86d535060c9c2b25e71e87c39ab2f22fc96e9636bd74d1dbf9de448c", size = 38702770, upload-time = "2025-05-08T16:04:20.849Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/6e/0c3bf90fae0e910c274db43304ebe25a6b391327f3f10b5dcc638c090795/scipy-1.15.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:ad3432cb0f9ed87477a8d97f03b763fd1d57709f1bbde3c9369b1dff5503b253", size = 30094511, upload-time = "2025-05-08T16:04:27.103Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b1/4deb37252311c1acff7f101f6453f0440794f51b6eacb1aad4459a134081/scipy-1.15.3-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:aef683a9ae6eb00728a542b796f52a5477b78252edede72b8327a886ab63293f", size = 22368151, upload-time = "2025-05-08T16:04:31.731Z" },
+    { url = "https://files.pythonhosted.org/packages/38/7d/f457626e3cd3c29b3a49ca115a304cebb8cc6f31b04678f03b216899d3c6/scipy-1.15.3-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:1c832e1bd78dea67d5c16f786681b28dd695a8cb1fb90af2e27580d3d0967e92", size = 25121732, upload-time = "2025-05-08T16:04:36.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/0a/92b1de4a7adc7a15dcf5bddc6e191f6f29ee663b30511ce20467ef9b82e4/scipy-1.15.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:263961f658ce2165bbd7b99fa5135195c3a12d9bef045345016b8b50c315cb82", size = 35547617, upload-time = "2025-05-08T16:04:43.546Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/6d/41991e503e51fc1134502694c5fa7a1671501a17ffa12716a4a9151af3df/scipy-1.15.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e2abc762b0811e09a0d3258abee2d98e0c703eee49464ce0069590846f31d40", size = 37662964, upload-time = "2025-05-08T16:04:49.431Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e1/3df8f83cb15f3500478c889be8fb18700813b95e9e087328230b98d547ff/scipy-1.15.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ed7284b21a7a0c8f1b6e5977ac05396c0d008b89e05498c8b7e8f4a1423bba0e", size = 37238749, upload-time = "2025-05-08T16:04:55.215Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3e/b3257cf446f2a3533ed7809757039016b74cd6f38271de91682aa844cfc5/scipy-1.15.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5380741e53df2c566f4d234b100a484b420af85deb39ea35a1cc1be84ff53a5c", size = 40022383, upload-time = "2025-05-08T16:05:01.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/55bc4881973d3f79b479a5a2e2df61c8c9a04fcb986a213ac9c02cfb659b/scipy-1.15.3-cp310-cp310-win_amd64.whl", hash = "sha256:9d61e97b186a57350f6d6fd72640f9e99d5a4a2b8fbf4b9ee9a841eab327dc13", size = 41259201, upload-time = "2025-05-08T16:05:08.166Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ab/5cc9f80f28f6a7dff646c5756e559823614a42b1939d86dd0ed550470210/scipy-1.15.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:993439ce220d25e3696d1b23b233dd010169b62f6456488567e830654ee37a6b", size = 38714255, upload-time = "2025-05-08T16:05:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4a/66ba30abe5ad1a3ad15bfb0b59d22174012e8056ff448cb1644deccbfed2/scipy-1.15.3-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:34716e281f181a02341ddeaad584205bd2fd3c242063bd3423d61ac259ca7eba", size = 30111035, upload-time = "2025-05-08T16:05:20.152Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/a7e5b95afd80d24313307f03624acc65801846fa75599034f8ceb9e2cbf6/scipy-1.15.3-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3b0334816afb8b91dab859281b1b9786934392aa3d527cd847e41bb6f45bee65", size = 22384499, upload-time = "2025-05-08T16:05:24.494Z" },
+    { url = "https://files.pythonhosted.org/packages/17/99/f3aaddccf3588bb4aea70ba35328c204cadd89517a1612ecfda5b2dd9d7a/scipy-1.15.3-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:6db907c7368e3092e24919b5e31c76998b0ce1684d51a90943cb0ed1b4ffd6c1", size = 25152602, upload-time = "2025-05-08T16:05:29.313Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c5/1032cdb565f146109212153339f9cb8b993701e9fe56b1c97699eee12586/scipy-1.15.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:721d6b4ef5dc82ca8968c25b111e307083d7ca9091bc38163fb89243e85e3889", size = 35503415, upload-time = "2025-05-08T16:05:34.699Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/37/89f19c8c05505d0601ed5650156e50eb881ae3918786c8fd7262b4ee66d3/scipy-1.15.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39cb9c62e471b1bb3750066ecc3a3f3052b37751c7c3dfd0fd7e48900ed52982", size = 37652622, upload-time = "2025-05-08T16:05:40.762Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/31/be59513aa9695519b18e1851bb9e487de66f2d31f835201f1b42f5d4d475/scipy-1.15.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:795c46999bae845966368a3c013e0e00947932d68e235702b5c3f6ea799aa8c9", size = 37244796, upload-time = "2025-05-08T16:05:48.119Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c0/4f5f3eeccc235632aab79b27a74a9130c6c35df358129f7ac8b29f562ac7/scipy-1.15.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:18aaacb735ab38b38db42cb01f6b92a2d0d4b6aabefeb07f02849e47f8fb3594", size = 40047684, upload-time = "2025-05-08T16:05:54.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a7/0ddaf514ce8a8714f6ed243a2b391b41dbb65251affe21ee3077ec45ea9a/scipy-1.15.3-cp311-cp311-win_amd64.whl", hash = "sha256:ae48a786a28412d744c62fd7816a4118ef97e5be0bee968ce8f0a2fba7acf3bb", size = 41246504, upload-time = "2025-05-08T16:06:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/683aa044c4162e10ed7a7ea30527f2cbd92e6999c10a8ed8edb253836e9c/scipy-1.15.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6ac6310fdbfb7aa6612408bd2f07295bcbd3fda00d2d702178434751fe48e019", size = 38766735, upload-time = "2025-05-08T16:06:06.471Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7e/f30be3d03de07f25dc0ec926d1681fed5c732d759ac8f51079708c79e680/scipy-1.15.3-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:185cd3d6d05ca4b44a8f1595af87f9c372bb6acf9c808e99aa3e9aa03bd98cf6", size = 30173284, upload-time = "2025-05-08T16:06:11.686Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9c/0ddb0d0abdabe0d181c1793db51f02cd59e4901da6f9f7848e1f96759f0d/scipy-1.15.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:05dc6abcd105e1a29f95eada46d4a3f251743cfd7d3ae8ddb4088047f24ea477", size = 22446958, upload-time = "2025-05-08T16:06:15.97Z" },
+    { url = "https://files.pythonhosted.org/packages/af/43/0bce905a965f36c58ff80d8bea33f1f9351b05fad4beaad4eae34699b7a1/scipy-1.15.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:06efcba926324df1696931a57a176c80848ccd67ce6ad020c810736bfd58eb1c", size = 25242454, upload-time = "2025-05-08T16:06:20.394Z" },
+    { url = "https://files.pythonhosted.org/packages/56/30/a6f08f84ee5b7b28b4c597aca4cbe545535c39fe911845a96414700b64ba/scipy-1.15.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c05045d8b9bfd807ee1b9f38761993297b10b245f012b11b13b91ba8945f7e45", size = 35210199, upload-time = "2025-05-08T16:06:26.159Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1f/03f52c282437a168ee2c7c14a1a0d0781a9a4a8962d84ac05c06b4c5b555/scipy-1.15.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:271e3713e645149ea5ea3e97b57fdab61ce61333f97cfae392c28ba786f9bb49", size = 37309455, upload-time = "2025-05-08T16:06:32.778Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b1/fbb53137f42c4bf630b1ffdfc2151a62d1d1b903b249f030d2b1c0280af8/scipy-1.15.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6cfd56fc1a8e53f6e89ba3a7a7251f7396412d655bca2aa5611c8ec9a6784a1e", size = 36885140, upload-time = "2025-05-08T16:06:39.249Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/2e/025e39e339f5090df1ff266d021892694dbb7e63568edcfe43f892fa381d/scipy-1.15.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0ff17c0bb1cb32952c09217d8d1eed9b53d1463e5f1dd6052c7857f83127d539", size = 39710549, upload-time = "2025-05-08T16:06:45.729Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/eb/3bf6ea8ab7f1503dca3a10df2e4b9c3f6b3316df07f6c0ded94b281c7101/scipy-1.15.3-cp312-cp312-win_amd64.whl", hash = "sha256:52092bc0472cfd17df49ff17e70624345efece4e1a12b23783a1ac59a1b728ed", size = 40966184, upload-time = "2025-05-08T16:06:52.623Z" },
+    { url = "https://files.pythonhosted.org/packages/73/18/ec27848c9baae6e0d6573eda6e01a602e5649ee72c27c3a8aad673ebecfd/scipy-1.15.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2c620736bcc334782e24d173c0fdbb7590a0a436d2fdf39310a8902505008759", size = 38728256, upload-time = "2025-05-08T16:06:58.696Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/1aef2184948728b4b6e21267d53b3339762c285a46a274ebb7863c9e4742/scipy-1.15.3-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:7e11270a000969409d37ed399585ee530b9ef6aa99d50c019de4cb01e8e54e62", size = 30109540, upload-time = "2025-05-08T16:07:04.209Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/d8/59e452c0a255ec352bd0a833537a3bc1bfb679944c4938ab375b0a6b3a3e/scipy-1.15.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:8c9ed3ba2c8a2ce098163a9bdb26f891746d02136995df25227a20e71c396ebb", size = 22383115, upload-time = "2025-05-08T16:07:08.998Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f5/456f56bbbfccf696263b47095291040655e3cbaf05d063bdc7c7517f32ac/scipy-1.15.3-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:0bdd905264c0c9cfa74a4772cdb2070171790381a5c4d312c973382fc6eaf730", size = 25163884, upload-time = "2025-05-08T16:07:14.091Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/66/a9618b6a435a0f0c0b8a6d0a2efb32d4ec5a85f023c2b79d39512040355b/scipy-1.15.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79167bba085c31f38603e11a267d862957cbb3ce018d8b38f79ac043bc92d825", size = 35174018, upload-time = "2025-05-08T16:07:19.427Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/09/c5b6734a50ad4882432b6bb7c02baf757f5b2f256041da5df242e2d7e6b6/scipy-1.15.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9deabd6d547aee2c9a81dee6cc96c6d7e9a9b1953f74850c179f91fdc729cb7", size = 37269716, upload-time = "2025-05-08T16:07:25.712Z" },
+    { url = "https://files.pythonhosted.org/packages/77/0a/eac00ff741f23bcabd352731ed9b8995a0a60ef57f5fd788d611d43d69a1/scipy-1.15.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:dde4fc32993071ac0c7dd2d82569e544f0bdaff66269cb475e0f369adad13f11", size = 36872342, upload-time = "2025-05-08T16:07:31.468Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/54/4379be86dd74b6ad81551689107360d9a3e18f24d20767a2d5b9253a3f0a/scipy-1.15.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f77f853d584e72e874d87357ad70f44b437331507d1c311457bed8ed2b956126", size = 39670869, upload-time = "2025-05-08T16:07:38.002Z" },
+    { url = "https://files.pythonhosted.org/packages/87/2e/892ad2862ba54f084ffe8cc4a22667eaf9c2bcec6d2bff1d15713c6c0703/scipy-1.15.3-cp313-cp313-win_amd64.whl", hash = "sha256:b90ab29d0c37ec9bf55424c064312930ca5f4bde15ee8619ee44e69319aab163", size = 40988851, upload-time = "2025-05-08T16:08:33.671Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/e9/7a879c137f7e55b30d75d90ce3eb468197646bc7b443ac036ae3fe109055/scipy-1.15.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3ac07623267feb3ae308487c260ac684b32ea35fd81e12845039952f558047b8", size = 38863011, upload-time = "2025-05-08T16:07:44.039Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d1/226a806bbd69f62ce5ef5f3ffadc35286e9fbc802f606a07eb83bf2359de/scipy-1.15.3-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:6487aa99c2a3d509a5227d9a5e889ff05830a06b2ce08ec30df6d79db5fcd5c5", size = 30266407, upload-time = "2025-05-08T16:07:49.891Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/9b/f32d1d6093ab9eeabbd839b0f7619c62e46cc4b7b6dbf05b6e615bbd4400/scipy-1.15.3-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:50f9e62461c95d933d5c5ef4a1f2ebf9a2b4e83b0db374cb3f1de104d935922e", size = 22540030, upload-time = "2025-05-08T16:07:54.121Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/29/c278f699b095c1a884f29fda126340fcc201461ee8bfea5c8bdb1c7c958b/scipy-1.15.3-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:14ed70039d182f411ffc74789a16df3835e05dc469b898233a245cdfd7f162cb", size = 25218709, upload-time = "2025-05-08T16:07:58.506Z" },
+    { url = "https://files.pythonhosted.org/packages/24/18/9e5374b617aba742a990581373cd6b68a2945d65cc588482749ef2e64467/scipy-1.15.3-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a769105537aa07a69468a0eefcd121be52006db61cdd8cac8a0e68980bbb723", size = 34809045, upload-time = "2025-05-08T16:08:03.929Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/fe/9c4361e7ba2927074360856db6135ef4904d505e9b3afbbcb073c4008328/scipy-1.15.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9db984639887e3dffb3928d118145ffe40eff2fa40cb241a306ec57c219ebbbb", size = 36703062, upload-time = "2025-05-08T16:08:09.558Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8e/038ccfe29d272b30086b25a4960f757f97122cb2ec42e62b460d02fe98e9/scipy-1.15.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:40e54d5c7e7ebf1aa596c374c49fa3135f04648a0caabcb66c52884b943f02b4", size = 36393132, upload-time = "2025-05-08T16:08:15.34Z" },
+    { url = "https://files.pythonhosted.org/packages/10/7e/5c12285452970be5bdbe8352c619250b97ebf7917d7a9a9e96b8a8140f17/scipy-1.15.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5e721fed53187e71d0ccf382b6bf977644c533e506c4d33c3fb24de89f5c3ed5", size = 38979503, upload-time = "2025-05-08T16:08:21.513Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/0a5e5349474e1cbc5757975b21bd4fad0e72ebf138c5592f191646154e06/scipy-1.15.3-cp313-cp313t-win_amd64.whl", hash = "sha256:76ad1fb5f8752eabf0fa02e4cc0336b4e8f021e2d5f061ed37d6d264db35e3ca", size = 40308097, upload-time = "2025-05-08T16:08:27.627Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and sys_platform != 'linux'",
+    "python_full_version >= '3.11.11' and python_full_version < '3.12' and sys_platform == 'linux'",
+    "python_full_version >= '3.11.11' and python_full_version < '3.12' and sys_platform != 'linux'",
+    "python_full_version >= '3.11' and python_full_version < '3.11.11' and sys_platform == 'linux'",
+    "python_full_version >= '3.11' and python_full_version < '3.11.11' and sys_platform != 'linux'",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/4a/b927028464795439faec8eaf0b03b011005c487bb2d07409f28bf30879c4/scipy-1.16.1.tar.gz", hash = "sha256:44c76f9e8b6e8e488a586190ab38016e4ed2f8a038af7cd3defa903c0a2238b3", size = 30580861, upload-time = "2025-07-27T16:33:30.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/91/812adc6f74409b461e3a5fa97f4f74c769016919203138a3bf6fc24ba4c5/scipy-1.16.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:c033fa32bab91dc98ca59d0cf23bb876454e2bb02cbe592d5023138778f70030", size = 36552519, upload-time = "2025-07-27T16:26:29.658Z" },
+    { url = "https://files.pythonhosted.org/packages/47/18/8e355edcf3b71418d9e9f9acd2708cc3a6c27e8f98fde0ac34b8a0b45407/scipy-1.16.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:6e5c2f74e5df33479b5cd4e97a9104c511518fbd979aa9b8f6aec18b2e9ecae7", size = 28638010, upload-time = "2025-07-27T16:26:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/eb/e931853058607bdfbc11b86df19ae7a08686121c203483f62f1ecae5989c/scipy-1.16.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:0a55ffe0ba0f59666e90951971a884d1ff6f4ec3275a48f472cfb64175570f77", size = 20909790, upload-time = "2025-07-27T16:26:43.93Z" },
+    { url = "https://files.pythonhosted.org/packages/45/0c/be83a271d6e96750cd0be2e000f35ff18880a46f05ce8b5d3465dc0f7a2a/scipy-1.16.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:f8a5d6cd147acecc2603fbd382fed6c46f474cccfcf69ea32582e033fb54dcfe", size = 23513352, upload-time = "2025-07-27T16:26:50.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/bf/fe6eb47e74f762f933cca962db7f2c7183acfdc4483bd1c3813cfe83e538/scipy-1.16.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb18899127278058bcc09e7b9966d41a5a43740b5bb8dcba401bd983f82e885b", size = 33534643, upload-time = "2025-07-27T16:26:57.503Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/ba/63f402e74875486b87ec6506a4f93f6d8a0d94d10467280f3d9d7837ce3a/scipy-1.16.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adccd93a2fa937a27aae826d33e3bfa5edf9aa672376a4852d23a7cd67a2e5b7", size = 35376776, upload-time = "2025-07-27T16:27:06.639Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b4/04eb9d39ec26a1b939689102da23d505ea16cdae3dbb18ffc53d1f831044/scipy-1.16.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:18aca1646a29ee9a0625a1be5637fa798d4d81fdf426481f06d69af828f16958", size = 35698906, upload-time = "2025-07-27T16:27:14.943Z" },
+    { url = "https://files.pythonhosted.org/packages/04/d6/bb5468da53321baeb001f6e4e0d9049eadd175a4a497709939128556e3ec/scipy-1.16.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d85495cef541729a70cdddbbf3e6b903421bc1af3e8e3a9a72a06751f33b7c39", size = 38129275, upload-time = "2025-07-27T16:27:23.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/94/994369978509f227cba7dfb9e623254d0d5559506fe994aef4bea3ed469c/scipy-1.16.1-cp311-cp311-win_amd64.whl", hash = "sha256:226652fca853008119c03a8ce71ffe1b3f6d2844cc1686e8f9806edafae68596", size = 38644572, upload-time = "2025-07-27T16:27:32.637Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d9/ec4864f5896232133f51382b54a08de91a9d1af7a76dfa372894026dfee2/scipy-1.16.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:81b433bbeaf35728dad619afc002db9b189e45eebe2cd676effe1fb93fef2b9c", size = 36575194, upload-time = "2025-07-27T16:27:41.321Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/6d/40e81ecfb688e9d25d34a847dca361982a6addf8e31f0957b1a54fbfa994/scipy-1.16.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:886cc81fdb4c6903a3bb0464047c25a6d1016fef77bb97949817d0c0d79f9e04", size = 28594590, upload-time = "2025-07-27T16:27:49.204Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/37/9f65178edfcc629377ce9a64fc09baebea18c80a9e57ae09a52edf84880b/scipy-1.16.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:15240c3aac087a522b4eaedb09f0ad061753c5eebf1ea430859e5bf8640d5919", size = 20866458, upload-time = "2025-07-27T16:27:54.98Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/7b/749a66766871ea4cb1d1ea10f27004db63023074c22abed51f22f09770e0/scipy-1.16.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:65f81a25805f3659b48126b5053d9e823d3215e4a63730b5e1671852a1705921", size = 23539318, upload-time = "2025-07-27T16:28:01.604Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/db/8d4afec60eb833a666434d4541a3151eedbf2494ea6d4d468cbe877f00cd/scipy-1.16.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6c62eea7f607f122069b9bad3f99489ddca1a5173bef8a0c75555d7488b6f725", size = 33292899, upload-time = "2025-07-27T16:28:09.147Z" },
+    { url = "https://files.pythonhosted.org/packages/51/1e/79023ca3bbb13a015d7d2757ecca3b81293c663694c35d6541b4dca53e98/scipy-1.16.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f965bbf3235b01c776115ab18f092a95aa74c271a52577bcb0563e85738fd618", size = 35162637, upload-time = "2025-07-27T16:28:17.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/49/0648665f9c29fdaca4c679182eb972935b3b4f5ace41d323c32352f29816/scipy-1.16.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f006e323874ffd0b0b816d8c6a8e7f9a73d55ab3b8c3f72b752b226d0e3ac83d", size = 35490507, upload-time = "2025-07-27T16:28:25.705Z" },
+    { url = "https://files.pythonhosted.org/packages/62/8f/66cbb9d6bbb18d8c658f774904f42a92078707a7c71e5347e8bf2f52bb89/scipy-1.16.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e8fd15fc5085ab4cca74cb91fe0a4263b1f32e4420761ddae531ad60934c2119", size = 37923998, upload-time = "2025-07-27T16:28:34.339Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c3/61f273ae550fbf1667675701112e380881905e28448c080b23b5a181df7c/scipy-1.16.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7b8013c6c066609577d910d1a2a077021727af07b6fab0ee22c2f901f22352a", size = 38508060, upload-time = "2025-07-27T16:28:43.242Z" },
+    { url = "https://files.pythonhosted.org/packages/93/0b/b5c99382b839854a71ca9482c684e3472badc62620287cbbdab499b75ce6/scipy-1.16.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5451606823a5e73dfa621a89948096c6528e2896e40b39248295d3a0138d594f", size = 36533717, upload-time = "2025-07-27T16:28:51.706Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e5/69ab2771062c91e23e07c12e7d5033a6b9b80b0903ee709c3c36b3eb520c/scipy-1.16.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:89728678c5ca5abd610aee148c199ac1afb16e19844401ca97d43dc548a354eb", size = 28570009, upload-time = "2025-07-27T16:28:57.017Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/69/bd75dbfdd3cf524f4d753484d723594aed62cfaac510123e91a6686d520b/scipy-1.16.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e756d688cb03fd07de0fffad475649b03cb89bee696c98ce508b17c11a03f95c", size = 20841942, upload-time = "2025-07-27T16:29:01.152Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/74/add181c87663f178ba7d6144b370243a87af8476664d5435e57d599e6874/scipy-1.16.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:5aa2687b9935da3ed89c5dbed5234576589dd28d0bf7cd237501ccfbdf1ad608", size = 23498507, upload-time = "2025-07-27T16:29:05.202Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/74/ece2e582a0d9550cee33e2e416cc96737dce423a994d12bbe59716f47ff1/scipy-1.16.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0851f6a1e537fe9399f35986897e395a1aa61c574b178c0d456be5b1a0f5ca1f", size = 33286040, upload-time = "2025-07-27T16:29:10.201Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/82/08e4076df538fb56caa1d489588d880ec7c52d8273a606bb54d660528f7c/scipy-1.16.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fedc2cbd1baed37474b1924c331b97bdff611d762c196fac1a9b71e67b813b1b", size = 35176096, upload-time = "2025-07-27T16:29:17.091Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/79/cd710aab8c921375711a8321c6be696e705a120e3011a643efbbcdeeabcc/scipy-1.16.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2ef500e72f9623a6735769e4b93e9dcb158d40752cdbb077f305487e3e2d1f45", size = 35490328, upload-time = "2025-07-27T16:29:22.928Z" },
+    { url = "https://files.pythonhosted.org/packages/71/73/e9cc3d35ee4526d784520d4494a3e1ca969b071fb5ae5910c036a375ceec/scipy-1.16.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:978d8311674b05a8f7ff2ea6c6bce5d8b45a0cb09d4c5793e0318f448613ea65", size = 37939921, upload-time = "2025-07-27T16:29:29.108Z" },
+    { url = "https://files.pythonhosted.org/packages/21/12/c0efd2941f01940119b5305c375ae5c0fcb7ec193f806bd8f158b73a1782/scipy-1.16.1-cp313-cp313-win_amd64.whl", hash = "sha256:81929ed0fa7a5713fcdd8b2e6f73697d3b4c4816d090dd34ff937c20fa90e8ab", size = 38479462, upload-time = "2025-07-27T16:30:24.078Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/19/c3d08b675260046a991040e1ea5d65f91f40c7df1045fffff412dcfc6765/scipy-1.16.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:bcc12db731858abda693cecdb3bdc9e6d4bd200213f49d224fe22df82687bdd6", size = 36938832, upload-time = "2025-07-27T16:29:35.057Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f2/ce53db652c033a414a5b34598dba6b95f3d38153a2417c5a3883da429029/scipy-1.16.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:744d977daa4becb9fc59135e75c069f8d301a87d64f88f1e602a9ecf51e77b27", size = 29093084, upload-time = "2025-07-27T16:29:40.201Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ae/7a10ff04a7dc15f9057d05b33737ade244e4bd195caa3f7cc04d77b9e214/scipy-1.16.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:dc54f76ac18073bcecffb98d93f03ed6b81a92ef91b5d3b135dcc81d55a724c7", size = 21365098, upload-time = "2025-07-27T16:29:44.295Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ac/029ff710959932ad3c2a98721b20b405f05f752f07344622fd61a47c5197/scipy-1.16.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:367d567ee9fc1e9e2047d31f39d9d6a7a04e0710c86e701e053f237d14a9b4f6", size = 23896858, upload-time = "2025-07-27T16:29:48.784Z" },
+    { url = "https://files.pythonhosted.org/packages/71/13/d1ef77b6bd7898720e1f0b6b3743cb945f6c3cafa7718eaac8841035ab60/scipy-1.16.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4cf5785e44e19dcd32a0e4807555e1e9a9b8d475c6afff3d21c3c543a6aa84f4", size = 33438311, upload-time = "2025-07-27T16:29:54.164Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e0/e64a6821ffbb00b4c5b05169f1c1fddb4800e9307efe3db3788995a82a2c/scipy-1.16.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3d0b80fb26d3e13a794c71d4b837e2a589d839fd574a6bbb4ee1288c213ad4a3", size = 35279542, upload-time = "2025-07-27T16:30:00.249Z" },
+    { url = "https://files.pythonhosted.org/packages/57/59/0dc3c8b43e118f1e4ee2b798dcc96ac21bb20014e5f1f7a8e85cc0653bdb/scipy-1.16.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:8503517c44c18d1030d666cb70aaac1cc8913608816e06742498833b128488b7", size = 35667665, upload-time = "2025-07-27T16:30:05.916Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5f/844ee26e34e2f3f9f8febb9343748e72daeaec64fe0c70e9bf1ff84ec955/scipy-1.16.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:30cc4bb81c41831ecfd6dc450baf48ffd80ef5aed0f5cf3ea775740e80f16ecc", size = 38045210, upload-time = "2025-07-27T16:30:11.655Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/d7/210f2b45290f444f1de64bc7353aa598ece9f0e90c384b4a156f9b1a5063/scipy-1.16.1-cp313-cp313t-win_amd64.whl", hash = "sha256:c24fa02f7ed23ae514460a22c57eca8f530dbfa50b1cfdbf4f37c05b5309cc39", size = 38593661, upload-time = "2025-07-27T16:30:17.825Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ea/84d481a5237ed223bd3d32d6e82d7a6a96e34756492666c260cef16011d1/scipy-1.16.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:796a5a9ad36fa3a782375db8f4241ab02a091308eb079746bc0f874c9b998318", size = 36525921, upload-time = "2025-07-27T16:30:30.081Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9f/d9edbdeff9f3a664807ae3aea383e10afaa247e8e6255e6d2aa4515e8863/scipy-1.16.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:3ea0733a2ff73fd6fdc5fecca54ee9b459f4d74f00b99aced7d9a3adb43fb1cc", size = 28564152, upload-time = "2025-07-27T16:30:35.336Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/95/8125bcb1fe04bc267d103e76516243e8d5e11229e6b306bda1024a5423d1/scipy-1.16.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:85764fb15a2ad994e708258bb4ed8290d1305c62a4e1ef07c414356a24fcfbf8", size = 20836028, upload-time = "2025-07-27T16:30:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/77/9c/bf92e215701fc70bbcd3d14d86337cf56a9b912a804b9c776a269524a9e9/scipy-1.16.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:ca66d980469cb623b1759bdd6e9fd97d4e33a9fad5b33771ced24d0cb24df67e", size = 23489666, upload-time = "2025-07-27T16:30:43.663Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/00/5e941d397d9adac41b02839011594620d54d99488d1be5be755c00cde9ee/scipy-1.16.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e7cc1ffcc230f568549fc56670bcf3df1884c30bd652c5da8138199c8c76dae0", size = 33358318, upload-time = "2025-07-27T16:30:48.982Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/87/8db3aa10dde6e3e8e7eb0133f24baa011377d543f5b19c71469cf2648026/scipy-1.16.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3ddfb1e8d0b540cb4ee9c53fc3dea3186f97711248fb94b4142a1b27178d8b4b", size = 35185724, upload-time = "2025-07-27T16:30:54.26Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b4/6ab9ae443216807622bcff02690262d8184078ea467efee2f8c93288a3b1/scipy-1.16.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4dc0e7be79e95d8ba3435d193e0d8ce372f47f774cffd882f88ea4e1e1ddc731", size = 35554335, upload-time = "2025-07-27T16:30:59.765Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/9a/d0e9dc03c5269a1afb60661118296a32ed5d2c24298af61b676c11e05e56/scipy-1.16.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f23634f9e5adb51b2a77766dac217063e764337fbc816aa8ad9aaebcd4397fd3", size = 37960310, upload-time = "2025-07-27T16:31:06.151Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/00/c8f3130a50521a7977874817ca89e0599b1b4ee8e938bad8ae798a0e1f0d/scipy-1.16.1-cp314-cp314-win_amd64.whl", hash = "sha256:57d75524cb1c5a374958a2eae3d84e1929bb971204cc9d52213fb8589183fc19", size = 39319239, upload-time = "2025-07-27T16:31:59.942Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f2/1ca3eda54c3a7e4c92f6acef7db7b3a057deb135540d23aa6343ef8ad333/scipy-1.16.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:d8da7c3dd67bcd93f15618938f43ed0995982eb38973023d46d4646c4283ad65", size = 36939460, upload-time = "2025-07-27T16:31:11.865Z" },
+    { url = "https://files.pythonhosted.org/packages/80/30/98c2840b293a132400c0940bb9e140171dcb8189588619048f42b2ce7b4f/scipy-1.16.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:cc1d2f2fd48ba1e0620554fe5bc44d3e8f5d4185c8c109c7fbdf5af2792cfad2", size = 29093322, upload-time = "2025-07-27T16:31:17.045Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/e6/1e6e006e850622cf2a039b62d1a6ddc4497d4851e58b68008526f04a9a00/scipy-1.16.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:21a611ced9275cb861bacadbada0b8c0623bc00b05b09eb97f23b370fc2ae56d", size = 21365329, upload-time = "2025-07-27T16:31:21.188Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/02/72a5aa5b820589dda9a25e329ca752842bfbbaf635e36bc7065a9b42216e/scipy-1.16.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:8dfbb25dffc4c3dd9371d8ab456ca81beeaf6f9e1c2119f179392f0dc1ab7695", size = 23897544, upload-time = "2025-07-27T16:31:25.408Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/dc/7122d806a6f9eb8a33532982234bed91f90272e990f414f2830cfe656e0b/scipy-1.16.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f0ebb7204f063fad87fc0a0e4ff4a2ff40b2a226e4ba1b7e34bf4b79bf97cd86", size = 33442112, upload-time = "2025-07-27T16:31:30.62Z" },
+    { url = "https://files.pythonhosted.org/packages/24/39/e383af23564daa1021a5b3afbe0d8d6a68ec639b943661841f44ac92de85/scipy-1.16.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f1b9e5962656f2734c2b285a8745358ecb4e4efbadd00208c80a389227ec61ff", size = 35286594, upload-time = "2025-07-27T16:31:36.112Z" },
+    { url = "https://files.pythonhosted.org/packages/95/47/1a0b0aff40c3056d955f38b0df5d178350c3d74734ec54f9c68d23910be5/scipy-1.16.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e1a106f8c023d57a2a903e771228bf5c5b27b5d692088f457acacd3b54511e4", size = 35665080, upload-time = "2025-07-27T16:31:42.025Z" },
+    { url = "https://files.pythonhosted.org/packages/64/df/ce88803e9ed6e27fe9b9abefa157cf2c80e4fa527cf17ee14be41f790ad4/scipy-1.16.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:709559a1db68a9abc3b2c8672c4badf1614f3b440b3ab326d86a5c0491eafae3", size = 38050306, upload-time = "2025-07-27T16:31:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6c/a76329897a7cae4937d403e623aa6aaea616a0bb5b36588f0b9d1c9a3739/scipy-1.16.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c0c804d60492a0aad7f5b2bb1862f4548b990049e27e828391ff2bf6f7199998", size = 39427705, upload-time = "2025-07-27T16:31:53.96Z" },
+]
+
+[[package]]
 name = "sentencepiece"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3649,11 +3913,13 @@ notebooks = [
 ]
 scripts = [
     { name = "captum" },
+    { name = "lczerolens" },
     { name = "loguru" },
     { name = "matplotlib" },
     { name = "nnsight" },
     { name = "numpy" },
     { name = "pyside6" },
+    { name = "scikit-learn" },
     { name = "transformer-lens" },
     { name = "zennit", version = "0.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11.11'" },
     { name = "zennit", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11.11'" },
@@ -3688,11 +3954,13 @@ docs = [
 notebooks = [{ name = "ipykernel", specifier = ">=6.29.5" }]
 scripts = [
     { name = "captum", specifier = ">=0.8.0" },
+    { name = "lczerolens", git = "https://github.com/Xmaster6y/lczerolens?branch=chores" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "matplotlib", specifier = ">=3.8.0" },
     { name = "nnsight", specifier = ">=0.4.11" },
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "pyside6", specifier = ">=6.9.1" },
+    { name = "scikit-learn", specifier = ">=1.7.1" },
     { name = "transformer-lens", specifier = ">=2.15.4" },
     { name = "zennit", specifier = ">=0.5.1" },
 ]
@@ -3731,6 +3999,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/a0/e93333dfdda27eba6e61ea660cdf2e0bdc968f8fef4c0b627c7eadad16a2/tensordict-0.9.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:bb6ea57b991c5083988203b636a84e0ddeac9e2df2bd24896899b241422364dc", size = 426368, upload-time = "2025-07-14T12:52:26.894Z" },
     { url = "https://files.pythonhosted.org/packages/02/26/72ab75eaba26b71228d4a644502e20c15cfdc35a8501cab049bc7182f49e/tensordict-0.9.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:1445c2d42737852a5f327c84ce0312fefb881c88852224e76aa86767aef6051c", size = 428895, upload-time = "2025-07-14T12:52:27.82Z" },
     { url = "https://files.pythonhosted.org/packages/c6/82/8b5951d3d37cc486185366ac532ca36363a6b2f7cdbe46e7010fdae192d5/tensordict-0.9.1-cp313-cp313t-win_amd64.whl", hash = "sha256:d94c54c3b8feff5c1fff47e54a0e4829c2fb4aeeb75d8ec413913849b721f855", size = 486525, upload-time = "2025-07-14T12:52:28.76Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]
@@ -4006,7 +4283,7 @@ name = "triton"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools" },
+    { name = "setuptools", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/a9/549e51e9b1b2c9b854fd761a1d23df0ba2fbc60bd0c13b489ffa518cfcb7/triton-3.3.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b74db445b1c562844d3cfad6e9679c72e93fdfb1a90a24052b03bb5c49d1242e", size = 155600257, upload-time = "2025-05-29T23:39:36.085Z" },


### PR DESCRIPTION
## What does this PR do?

Focus on `TensorDictModule` support.

## Linked Issues

- Closes #?
- #?

## Summary by Sourcery

Refactor core API and attribution machinery to fully embrace TensorDictModuleBase pipelines, replace low-level PyTorch hooks with TensorDictSequential flows, introduce utilities for TensorDict gradient operations, update context factories and hooked modules for relative key handling, revamp bench scripts CLI, and align tests and docs with the new TensorDict-driven workflow

New Features:
- Introduce FunctionModule and td_grad utilities to build custom TensorDictModule pipelines for attribution
- Add UnraveledKey type to support tuple-based TensorDict keys
- Provide HookedModule.from_module factory method for simplified instantiation

Bug Fixes:
- Enforce Tensor-only caching in hooks and improve errors on type mismatches

Enhancements:
- Refactor GradientAttribution and GradientAttributionWithBaseline to construct attribution pipelines via TensorDictSequential rather than PyTorch hooks, supporting multiple init_targets, init_grads, and additional init keys
- Redesign HookingContextFactory, HookingContext, and HookedModule to natively prepare and spawn TensorDictModuleBase, enable relative submodule path resolution, and unify get/set/stop APIs
- Enhance ActivationCaching and LinearProbing to accept relative naming patterns and back caches with TensorDict
- Convert all bench and task scripts under scripts/bench to use argparse for configurable --tasks, --seeds, --output-file and --output-dir parameters

Build:
- Add new dependencies (lczerolens, scikit-learn, torchrl, gymnasium) in pyproject.toml
- Bump pre-commit and ruff hook versions in .pre-commit-config.yaml

Documentation:
- Update README badges to include PyPI, codecov, and docs links

Tests:
- Revise tests across test_module, test_contexts, attribution, activation caching, and linear probing to use tuple-based keys, .from_module API, and relative key matching