### PR TITLE
[Feature] Multi batch size support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,14 @@ jobs:
     - name: Run tests
       run: |
         just tests
+    - name: Upload coverage reports to Codecov
+      if: matrix.python-version == '3.10'
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+    - name: Upload test results to Codecov
+      if: matrix.python-version == '3.10' && ${{ !cancelled() }}
+      uses: codecov/test-results-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true

--- a/scripts/bench/tasks/gpt2_cache/_nnsight.py
+++ b/scripts/bench/tasks/gpt2_cache/_nnsight.py
@@ -43,7 +43,19 @@ def run(
     return logits, {k: v for k, v in activations.items() if v.node.executed}
 
 
-def main(args: argparse.Namespace):
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("gpt2-cache-nnsight")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--model_size", type=str, default="gpt2")
+    parser.add_argument("--batch_size", type=int, default=10)
+    parser.add_argument("--variation", type=str, default="specific")
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -73,17 +85,5 @@ def main(args: argparse.Namespace):
         logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser("gpt2-cache-nnsight")
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--model_size", type=str, default="gpt2")
-    parser.add_argument("--batch_size", type=int, default=10)
-    parser.add_argument("--variation", type=str, default="specific")
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
-    args = parse_args()
-    main(args)
+    main()

--- a/scripts/bench/tasks/gpt2_cache/_tdhook.py
+++ b/scripts/bench/tasks/gpt2_cache/_tdhook.py
@@ -50,7 +50,19 @@ def run(
     return shuttle["output", "logits"], context.cache
 
 
-def main(args: argparse.Namespace):
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("gpt2-cache-tdhook")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--model_size", type=str, default="gpt2")
+    parser.add_argument("--batch_size", type=int, default=10)
+    parser.add_argument("--variation", type=str, default="specific")
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -80,17 +92,5 @@ def main(args: argparse.Namespace):
         logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser("gpt2-cache-tdhook")
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--model_size", type=str, default="gpt2")
-    parser.add_argument("--batch_size", type=int, default=10)
-    parser.add_argument("--variation", type=str, default="specific")
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
-    args = parse_args()
-    main(args)
+    main()

--- a/scripts/bench/tasks/gpt2_cache/_transformer_lens.py
+++ b/scripts/bench/tasks/gpt2_cache/_transformer_lens.py
@@ -40,7 +40,19 @@ def run(
     return model.run_with_cache(**input_data)
 
 
-def main(args: argparse.Namespace):
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("gpt2-cache-transformer-lens")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--model_size", type=str, default="gpt2")
+    parser.add_argument("--batch_size", type=int, default=10)
+    parser.add_argument("--variation", type=str, default="specific")
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -70,17 +82,5 @@ def main(args: argparse.Namespace):
         logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser("gpt2-cache-transformer-lens")
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--model_size", type=str, default="gpt2")
-    parser.add_argument("--batch_size", type=int, default=10)
-    parser.add_argument("--variation", type=str, default="specific")
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
-    args = parse_args()
-    main(args)
+    main()

--- a/scripts/bench/tasks/integrated_gradients/_captum.py
+++ b/scripts/bench/tasks/integrated_gradients/_captum.py
@@ -51,7 +51,20 @@ def run(
     return attributions, delta
 
 
-def main(args: argparse.Namespace):
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("integrated-gradients-captum")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--width", type=int, default=10)
+    parser.add_argument("--height", type=int, default=10)
+    parser.add_argument("--batch_size", type=int, default=10)
+    parser.add_argument("--variation", type=str, default="multiply")
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -82,18 +95,5 @@ def main(args: argparse.Namespace):
         logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser("integrated-gradients-captum")
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--width", type=int, default=10)
-    parser.add_argument("--height", type=int, default=10)
-    parser.add_argument("--batch_size", type=int, default=10)
-    parser.add_argument("--variation", type=str, default="multiply")
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
-    args = parse_args()
-    main(args)
+    main()

--- a/scripts/bench/tasks/integrated_gradients/_captum_add.py
+++ b/scripts/bench/tasks/integrated_gradients/_captum_add.py
@@ -52,7 +52,20 @@ def run(
     return attributions1 + attributions2, delta1 + delta2
 
 
-def main(args: argparse.Namespace):
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("integrated-gradients-captum-add")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--width", type=int, default=10)
+    parser.add_argument("--height", type=int, default=10)
+    parser.add_argument("--batch_size", type=int, default=10)
+    parser.add_argument("--variation", type=str, default="multiply")
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -83,18 +96,5 @@ def main(args: argparse.Namespace):
         logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser("integrated-gradients-captum-add")
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--width", type=int, default=10)
-    parser.add_argument("--height", type=int, default=10)
-    parser.add_argument("--batch_size", type=int, default=10)
-    parser.add_argument("--variation", type=str, default="multiply")
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
-    args = parse_args()
-    main(args)
+    main()

--- a/scripts/bench/tasks/integrated_gradients/_tdhook.py
+++ b/scripts/bench/tasks/integrated_gradients/_tdhook.py
@@ -42,7 +42,7 @@ def prepare(
     input_data = torch.randn(batch_size, width).to("cuda" if use_cuda else "cpu")
     baseline = torch.zeros_like(input_data)
     context_factory = IntegratedGradients(
-        init_targets=lambda td, _: td[:, (4, 7)],
+        init_attr_targets=lambda td, _: td.apply(lambda t: t[..., (4, 7)]),
         multiply_by_inputs=variation == "multiply",
         compute_convergence_delta=True,
     )

--- a/scripts/bench/tasks/integrated_gradients/_tdhook.py
+++ b/scripts/bench/tasks/integrated_gradients/_tdhook.py
@@ -42,7 +42,7 @@ def prepare(
     input_data = torch.randn(batch_size, width).to("cuda" if use_cuda else "cpu")
     baseline = torch.zeros_like(input_data)
     context_factory = IntegratedGradients(
-        init_target=lambda x: x[:, (4, 7)],
+        init_targets=lambda td, _: td[:, (4, 7)],
         multiply_by_inputs=variation == "multiply",
         compute_convergence_delta=True,
     )
@@ -57,12 +57,25 @@ def run(
     """Benchmark a single model configuration."""
     with hooking_context as hooked_module:
         output = hooked_module(
-            TensorDict({"input": input_data, "input_baseline": baseline}, batch_size=input_data.shape[0])
+            TensorDict({"input": input_data, ("baseline", "input"): baseline}, batch_size=input_data.shape[0])
         )
-        return output["input_attr"], output["convergence_delta"]
+        return output[("attr", "input")], output["convergence_delta"]
 
 
-def main(args: argparse.Namespace):
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("integrated-gradients-tdhook")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--width", type=int, default=10)
+    parser.add_argument("--height", type=int, default=10)
+    parser.add_argument("--batch_size", type=int, default=10)
+    parser.add_argument("--variation", type=str, default="multiply")
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -93,18 +106,5 @@ def main(args: argparse.Namespace):
         logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser("integrated-gradients-tdhook")
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--width", type=int, default=10)
-    parser.add_argument("--height", type=int, default=10)
-    parser.add_argument("--batch_size", type=int, default=10)
-    parser.add_argument("--variation", type=str, default="multiply")
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
-    args = parse_args()
-    main(args)
+    main()

--- a/scripts/bench/tasks/lrp/_tdhook.py
+++ b/scripts/bench/tasks/lrp/_tdhook.py
@@ -52,10 +52,23 @@ def run(
 
     with hooking_context as hooked_module:
         output = hooked_module(TensorDict({"input": input_data}, batch_size=input_data.shape[0]))
-        return output["input_attr"]
+        return output[("attr", "input")]
 
 
-def main(args: argparse.Namespace):
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("lrp-tdhook")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--width", type=int, default=10)
+    parser.add_argument("--height", type=int, default=10)
+    parser.add_argument("--batch_size", type=int, default=10)
+    parser.add_argument("--variation", type=str, default="epsilon-plus")
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -86,18 +99,5 @@ def main(args: argparse.Namespace):
         logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser("lrp-tdhook")
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--width", type=int, default=10)
-    parser.add_argument("--height", type=int, default=10)
-    parser.add_argument("--batch_size", type=int, default=10)
-    parser.add_argument("--variation", type=str, default="epsilon-plus")
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
-    args = parse_args()
-    main(args)
+    main()

--- a/scripts/bench/tasks/lrp/_zennit.py
+++ b/scripts/bench/tasks/lrp/_zennit.py
@@ -53,7 +53,20 @@ def run(
         return input_data.grad
 
 
-def main(args: argparse.Namespace):
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("lrp-zennit")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--width", type=int, default=10)
+    parser.add_argument("--height", type=int, default=10)
+    parser.add_argument("--batch_size", type=int, default=10)
+    parser.add_argument("--variation", type=str, default="epsilon-plus")
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -84,18 +97,5 @@ def main(args: argparse.Namespace):
         logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser("lrp-zennit")
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--width", type=int, default=10)
-    parser.add_argument("--height", type=int, default=10)
-    parser.add_argument("--batch_size", type=int, default=10)
-    parser.add_argument("--variation", type=str, default="epsilon-plus")
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
-    args = parse_args()
-    main(args)
+    main()

--- a/scripts/bench/tasks/mlp_intervene/_nnsight.py
+++ b/scripts/bench/tasks/mlp_intervene/_nnsight.py
@@ -57,7 +57,20 @@ def run(
     return (state1, state2, state3)
 
 
-def main(args: argparse.Namespace):
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("mlp-intervene-nnsight")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--width", type=int, default=10)
+    parser.add_argument("--height", type=int, default=10)
+    parser.add_argument("--batch_size", type=int, default=10)
+    parser.add_argument("--variation", type=int, default=10)
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -88,18 +101,5 @@ def main(args: argparse.Namespace):
         logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser("mlp-intervene-nnsight")
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--width", type=int, default=10)
-    parser.add_argument("--height", type=int, default=10)
-    parser.add_argument("--batch_size", type=int, default=10)
-    parser.add_argument("--variation", type=int, default=10)
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
-    args = parse_args()
-    main(args)
+    main()

--- a/scripts/bench/tasks/mlp_intervene/_tdhook.py
+++ b/scripts/bench/tasks/mlp_intervene/_tdhook.py
@@ -60,7 +60,20 @@ def run(
     return (state1.resolve(), state2.resolve(), state3.resolve())
 
 
-def main(args: argparse.Namespace):
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("mlp-intervene-tdhook")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--width", type=int, default=10)
+    parser.add_argument("--height", type=int, default=10)
+    parser.add_argument("--batch_size", type=int, default=10)
+    parser.add_argument("--variation", type=int, default=10)
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
@@ -91,18 +104,5 @@ def main(args: argparse.Namespace):
         logger.info(f"  Max GPU memory: {torch.cuda.max_memory_allocated() / 1024:.2f} KB")
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser("mlp-intervene-tdhook")
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--width", type=int, default=10)
-    parser.add_argument("--height", type=int, default=10)
-    parser.add_argument("--batch_size", type=int, default=10)
-    parser.add_argument("--variation", type=int, default=10)
-    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--cuda", action=argparse.BooleanOptionalAction, default=True)
-    return parser.parse_args()
-
-
 if __name__ == "__main__":
-    args = parse_args()
-    main(args)
+    main()

--- a/scripts/torchrl/value_saliency.py
+++ b/scripts/torchrl/value_saliency.py
@@ -4,7 +4,7 @@ Script to compute saliency maps for a value network using tdhook.
 Run with:
 
 ```
-uv run --group scripts -m scripts.xdrl.value_saliency
+uv run --group scripts -m scripts.torchrl.value_saliency
 ```
 """
 

--- a/src/tdhook/attribution/gradient_attribution/common.py
+++ b/src/tdhook/attribution/gradient_attribution/common.py
@@ -10,46 +10,62 @@ from tensordict.nn import TensorDictModule, TensorDictSequential, TensorDictModu
 from tensordict import TensorDict
 
 from tdhook.contexts import HookingContextFactory
-from tdhook.module import HookedModule, FunctionModule
-from tdhook.hooks import MultiHookHandle
+from tdhook.module import FunctionModule, flatten_select_reshape_call
 from tdhook._types import UnraveledKey
 
 
 class GradientAttribution(HookingContextFactory, metaclass=ABCMeta):
     def __init__(
         self,
-        init_targets: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
-        init_grads: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
+        init_attr_targets: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
+        init_attr_inputs: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
+        init_attr_grads: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
         multiply_by_inputs: bool = False,
         additional_init_keys: Optional[List[UnraveledKey]] = None,
-        attribution_key: Optional[UnraveledKey] = None,
+        attribution_key: UnraveledKey = "attr",
+        clean_keys: bool = True,
+        keep_output_keys: bool = True,
     ):
-        self._init_targets = init_targets
-        self._init_grads = init_grads
+        self._init_attr_targets = init_attr_targets
+        self._init_attr_inputs = init_attr_inputs
+        self._init_attr_grads = init_attr_grads
+
         self._multiply_by_inputs = multiply_by_inputs
         self._additional_init_keys = additional_init_keys or []
-        self._attr_key = attribution_key or "attr"
+        self._attr_key = attribution_key
+        self._clean_keys = clean_keys  # TODO: clean intermediate keys
+        self._keep_output_keys = keep_output_keys  # TODO: move output keys before cleaning
 
     def _prepare_module(
         self, module: TensorDictModuleBase, in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
     ) -> TensorDictModuleBase:
         n_in_keys = len(in_keys)
-        saved_keys = [("saved", in_key) for in_key in in_keys]
+        register_in_keys = [("_register_in", in_key) for in_key in in_keys]
+        mod_in_keys = [("_mod_in", in_key) for in_key in in_keys]
+        mod_out_keys = [("_mod_out", out_key) for out_key in out_keys]
         attr_keys = [(self._attr_key, in_key) for in_key in in_keys]
 
         if set(self._additional_init_keys) & (set(in_keys) | set(out_keys)):
             raise ValueError("Additional init keys must not be in the in_keys or out_keys")
         modules = [
             TensorDictModule(
-                self._register_inputs_fn,
+                lambda *tensors: tensors,
                 in_keys=in_keys,
-                out_keys=saved_keys,
-                inplace=True,
+                out_keys=register_in_keys,
             ),
-            module,
             FunctionModule(
-                lambda td: self._attributor_fn(td, saved_keys, out_keys),
-                in_keys=saved_keys + out_keys + self._additional_init_keys,
+                self._register_inputs_fn,
+                in_keys=register_in_keys,
+                out_keys=mod_in_keys,
+            ),
+            FunctionModule(
+                lambda td: self._module_call_fn(td, module),
+                in_keys=mod_in_keys,
+                out_keys=mod_out_keys,
+            ),
+            FunctionModule(
+                self._attributor_fn,
+                in_keys=mod_in_keys + mod_out_keys + self._additional_init_keys,
                 out_keys=attr_keys,
             ),
         ]
@@ -57,34 +73,61 @@ class GradientAttribution(HookingContextFactory, metaclass=ABCMeta):
             modules.append(
                 TensorDictModule(
                     lambda *tensors: self._multiply_by_inputs_fn(tensors[:n_in_keys], tensors[n_in_keys:]),
-                    in_keys=saved_keys + attr_keys,
+                    in_keys=mod_in_keys + attr_keys,
                     out_keys=attr_keys,
                     inplace=True,
                 )
             )
         return TensorDictSequential(*modules)
 
-    def _register_inputs_fn(self, *inputs):  # TODO: needed with autograd?
-        return tuple(inp.requires_grad_(True) for inp in inputs)
+    def _register_inputs_fn(self, td: TensorDict) -> TensorDict:
+        inputs = td["_register_in"]
+        if self._init_attr_inputs is not None:
+            needs_grad = self._init_attr_inputs(inputs, td.select(*self._additional_init_keys))
+            if not isinstance(inputs, TensorDict):
+                raise ValueError("init_attr_inputs function must return a TensorDict")
+        else:
+            needs_grad = inputs
+        needs_grad.requires_grad_(True)
+        inputs.update(needs_grad)
+        td["_mod_in"] = inputs
+        return td
 
-    def _attributor_fn(
-        self, td: TensorDict, saved_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
-    ) -> TensorDict:
-        outputs = td.select(*out_keys)
+    def _module_call_fn(self, td: TensorDict, module: TensorDictModuleBase) -> TensorDict:
+        inputs = td["_mod_in"]
+        outputs = flatten_select_reshape_call(module, inputs)
+        td["_mod_out"] = outputs
+        return td
+
+    def _attributor_fn(self, td: TensorDict) -> TensorDict:
         additional_init_tensors = td.select(*self._additional_init_keys)
 
-        if self._init_targets is not None:
-            targets = self._init_targets(outputs, additional_init_tensors)
+        if self._init_attr_targets is not None:
+            targets = self._init_attr_targets(td["_mod_out"], additional_init_tensors)
             if not isinstance(targets, TensorDict):
-                raise ValueError("init_targets function must return a TensorDict")
+                raise ValueError("init_attr_targets function must return a TensorDict")
         else:
-            targets = outputs
-        if self._init_grads is not None:
-            init_grads = self._init_grads(targets, additional_init_tensors)
+            targets = td["_mod_out"]
+        if targets.batch_size != td["_mod_in"].batch_size:
+            raise ValueError("init_attr_targets should not change the batch size")
+
+        if self._init_attr_inputs is not None:
+            inputs = self._init_attr_inputs(td["_mod_in"], additional_init_tensors)
+            if not isinstance(inputs, TensorDict):
+                raise ValueError("init_attr_inputs function must return a TensorDict")
+        else:
+            inputs = td["_mod_in"]
+        if inputs.batch_size != td["_mod_in"].batch_size:
+            raise ValueError("init_attr_inputs should not change the batch size")
+
+        if self._init_attr_grads is not None:
+            init_grads = self._init_attr_grads(targets, additional_init_tensors)
             if not isinstance(init_grads, TensorDict):
-                raise ValueError("init_grads function must return a TensorDict")
+                raise ValueError("init_attr_grads function must return a TensorDict")
         else:
             init_grads = torch.ones_like(targets)
+        if init_grads.batch_size != targets.batch_size:
+            raise ValueError("init_grads should have the same batch size as targets")
 
         if set(targets.keys(True, True)) != set(init_grads.keys(True, True)):
             raise ValueError("Targets and init_grads must have the same keys")
@@ -92,10 +135,8 @@ class GradientAttribution(HookingContextFactory, metaclass=ABCMeta):
             if target.grad_fn is None:
                 raise ValueError(f"Target {target_key} has no grad_fn")
 
-        inputs = td.select(*saved_keys)
-
         grads = self._grad_attr(targets, inputs, init_grads)
-        td[self._attr_key] = grads["saved"]
+        td[self._attr_key] = grads
         return td
 
     @abstractmethod
@@ -113,38 +154,31 @@ class GradientAttribution(HookingContextFactory, metaclass=ABCMeta):
 
 
 class GradientAttributionWithBaseline(GradientAttribution):
-    def __init__(self, *args, compute_convergence_delta: bool = False, **kwargs):
+    def __init__(
+        self, *args, compute_convergence_delta: bool = False, baseline_key: UnraveledKey = "baseline", **kwargs
+    ):
         super().__init__(*args, **kwargs)
         self._compute_convergence_delta = compute_convergence_delta
+        self._baseline_key = baseline_key
 
     def _prepare_module(
         self, module: TensorDictModuleBase, in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
     ) -> TensorDictModuleBase:
         n_in_keys = len(in_keys)
-        saved_keys = [("saved", in_key) for in_key in in_keys]
+        register_in_keys = [("_register_in", in_key) for in_key in in_keys]
         attr_keys = [(self._attr_key, in_key) for in_key in in_keys]
-        baseline_keys = [("baseline", in_key) for in_key in in_keys]
-        (_, _, attributor_module, *_) = super()._prepare_module(module, in_keys, out_keys)
+        baseline_keys = [(self._baseline_key, in_key) for in_key in in_keys]
+        (_, register_inputs, module_call, attributor, *_) = super()._prepare_module(module, in_keys, out_keys)
 
         modules = [
-            TensorDictModule(
-                lambda *tensors: self._reduce_baselines_fn(tensors[:n_in_keys], tensors[n_in_keys:]),
-                in_keys=in_keys + baseline_keys,
-                out_keys=saved_keys,
-                inplace=True,
-            ),
-            TensorDictModule(
-                self._register_inputs_fn,
-                in_keys=saved_keys,
-                out_keys=saved_keys,
-                inplace=True,
-            ),
             FunctionModule(
-                lambda td: self._module_call_fn(td, module),
-                in_keys=saved_keys,
-                out_keys=out_keys,
+                lambda td: self._reduce_baselines_fn(td, in_keys),
+                in_keys=in_keys + baseline_keys,
+                out_keys=register_in_keys,
             ),
-            attributor_module,
+            register_inputs,
+            module_call,
+            attributor,
         ]
         if self._multiply_by_inputs:
             modules.append(
@@ -168,34 +202,8 @@ class GradientAttributionWithBaseline(GradientAttribution):
 
         return TensorDictSequential(*modules)
 
-    def _hook_module(self, module: HookedModule) -> MultiHookHandle:
-        handles = []
-
-        handles.append(
-            module.register_submodule_hook(
-                "td_module",
-                self._assert_batched_hook,  # TODO: support unbatched inputs
-                direction="fwd_pre",
-                relative=False,
-            )
-        )
-
-        handles.append(super()._hook_module(module))
-
-        return MultiHookHandle(handles)
-
-    def _assert_batched_hook(self, module, args):
-        if args[0].ndim == 0:
-            raise NotImplementedError("This attribution method requires batched inputs")
-
     @abstractmethod
-    def _reduce_baselines_fn(
-        self, inputs: Tuple[torch.Tensor, ...], baselines: Tuple[torch.Tensor, ...]
-    ) -> Tuple[torch.Tensor, ...]:
-        pass
-
-    @abstractmethod
-    def _module_call_fn(self, td: TensorDict, module: TensorDictModuleBase) -> TensorDict:
+    def _reduce_baselines_fn(self, td: TensorDict, in_keys: List[UnraveledKey]) -> TensorDict:
         pass
 
     @torch.no_grad()
@@ -212,23 +220,22 @@ class GradientAttributionWithBaseline(GradientAttribution):
         out_keys: List[UnraveledKey],
         module: TensorDictModuleBase,
     ) -> TensorDict:
-        baseline_keys = [("baseline", in_key) for in_key in in_keys]
-        attr_keys = [(self._attr_key, in_key) for in_key in in_keys]
-
         inputs = td.select(*in_keys)
-        baselines = td.select(*baseline_keys)["baseline"]
-        attrs = td.select(*attr_keys)
+        baselines = td[self._baseline_key]
+        attrs = td[self._attr_key]
         additional_init_tensors = td.select(*self._additional_init_keys)
 
-        if self._init_targets is not None:
-            start_out = self._init_targets(module(baselines), additional_init_tensors)
+        if self._init_attr_targets is not None:
+            start_out = self._init_attr_targets(
+                flatten_select_reshape_call(module, baselines), additional_init_tensors
+            )
         else:
-            start_out = module(baselines).select(*out_keys)
+            start_out = flatten_select_reshape_call(module, baselines)
         start_out_sum = start_out.sum(dim="feature", reduce=True)
-        if self._init_targets is not None:
-            end_out = self._init_targets(module(inputs), additional_init_tensors)
+        if self._init_attr_targets is not None:
+            end_out = self._init_attr_targets(flatten_select_reshape_call(module, inputs), additional_init_tensors)
         else:
-            end_out = module(inputs).select(*out_keys)
+            end_out = flatten_select_reshape_call(module, inputs)
         end_out_sum = end_out.sum(dim="feature", reduce=True)
 
         attr_sum = attrs.sum(dim="feature", reduce=True)

--- a/src/tdhook/attribution/gradient_attribution/integrated_gradients.py
+++ b/src/tdhook/attribution/gradient_attribution/integrated_gradients.py
@@ -3,14 +3,14 @@ Integrated gradients
 """
 
 import torch
-from typing import Tuple
-from tensordict.nn import TensorDictModuleBase
+from typing import List
 from tensordict import TensorDict, merge_tensordicts
 
 from .helpers import approximation_parameters
 
 from tdhook.attribution.gradient_attribution import GradientAttributionWithBaseline
 from tdhook.module import td_grad
+from tdhook._types import UnraveledKey
 
 
 class IntegratedGradients(GradientAttributionWithBaseline):
@@ -20,26 +20,31 @@ class IntegratedGradients(GradientAttributionWithBaseline):
         self._n_steps = n_steps
         self._step_sizes = None
 
-    def _reduce_baselines_fn(self, inputs: Tuple[torch.Tensor, ...], baselines: Tuple[torch.Tensor, ...]):
+    def _reduce_baselines_fn(self, td: TensorDict, in_keys: List[UnraveledKey]) -> TensorDict:
         step_sizes_func, alphas_func = approximation_parameters(self._method)
         step_sizes, alphas = step_sizes_func(self._n_steps), alphas_func(self._n_steps)
         self._step_sizes = step_sizes
 
-        return tuple(
-            torch.stack([baseline + alpha * (input - baseline) for alpha in alphas], dim=1).requires_grad_()
-            for input, baseline in zip(inputs, baselines)
+        inputs = td.select(*in_keys)
+        baselines = td[self._baseline_key]
+        additional_init_tensors = td.select(*self._additional_init_keys)
+
+        if self._init_attr_inputs is not None:
+            needs_baselines = self._init_attr_inputs(inputs, additional_init_tensors)
+            other_inputs = inputs.select(
+                *(k for k in inputs.keys(True, True) if k not in needs_baselines.keys(True, True))
+            )
+        else:
+            needs_baselines = inputs
+            other_inputs = TensorDict(batch_size=inputs.batch_size)
+
+        new_bs = (*inputs.batch_size, self._n_steps)
+        expanded_other_inputs = other_inputs.unsqueeze(-1).expand(new_bs)
+        reduced_baselines = torch.stack(
+            [baselines + alpha * (needs_baselines - baselines) for alpha in alphas], dim=-1
         )
-
-    def _module_call_fn(self, td: TensorDict, module: TensorDictModuleBase) -> TensorDict:
-        inputs = td["saved"]
-        inputs.batch_size = (*inputs.batch_size, self._n_steps)
-
-        outputs = module(inputs.flatten()).select(*module.out_keys).reshape(inputs.shape)
-
-        inputs.batch_size = inputs.batch_size[:-1]
-        outputs.batch_size = outputs.batch_size[:-1]
-
-        return merge_tensordicts(td, outputs.apply(self._permute_fn))  # TODO: update td inplace?
+        td["_register_in"] = merge_tensordicts(expanded_other_inputs, reduced_baselines)
+        return td
 
     def _grad_attr(
         self,
@@ -47,17 +52,22 @@ class IntegratedGradients(GradientAttributionWithBaseline):
         inputs: TensorDict,
         init_grads: TensorDict,
     ) -> TensorDict:
-        grads = td_grad(targets, inputs, init_grads).apply(self._permute_fn)
-
+        grads = td_grad(targets, inputs, init_grads)
         steps = torch.tensor(self._step_sizes).float().to(grads.device)
 
-        def multiply_sum_fn(grad: torch.Tensor) -> torch.Tensor:
-            return torch.sum(grad.mul_(steps), dim=-1)
-
-        return grads.apply(multiply_sum_fn)
+        return torch.sum(grads * steps, dim=-1)  # TODO: inplace (grads *= steps) not working
 
     @staticmethod
-    def _permute_fn(out: torch.Tensor) -> torch.Tensor:
-        n_out_dim = len(out.shape)
-        perm = (0,) + tuple(range(2, n_out_dim)) + (1,)
-        return out.permute(perm)
+    def init_attr_targets_with_labels(
+        outputs: TensorDict,
+        additional_init_tensors: TensorDict,
+        selected_out_keys: List[UnraveledKey],
+        label_key: UnraveledKey = "label",
+    ) -> TensorDict:
+        targets = outputs.select(*selected_out_keys)
+        labels = additional_init_tensors[label_key].unsqueeze(-1).expand(targets.shape)
+        d = {}
+        for k in targets.keys(True, True):
+            one_hot_labels = torch.nn.functional.one_hot(labels[k], num_classes=targets[k].shape[-1]).to(bool)
+            d[k] = targets[k][one_hot_labels].reshape(targets.batch_size)
+        return TensorDict(d, batch_size=targets.batch_size)

--- a/src/tdhook/attribution/gradient_attribution/integrated_gradients.py
+++ b/src/tdhook/attribution/gradient_attribution/integrated_gradients.py
@@ -69,5 +69,9 @@ class IntegratedGradients(GradientAttributionWithBaseline):
         d = {}
         for k in targets.keys(True, True):
             one_hot_labels = torch.nn.functional.one_hot(labels[k], num_classes=targets[k].shape[-1]).to(bool)
+            if one_hot_labels.shape != targets[k].shape:
+                raise ValueError(
+                    f"One-hot labels shape {one_hot_labels.shape} does not match target shape {targets[k].shape}"
+                )
             d[k] = targets[k][one_hot_labels].reshape(targets.batch_size)
         return TensorDict(d, batch_size=targets.batch_size)

--- a/src/tdhook/attribution/lrp/lrp.py
+++ b/src/tdhook/attribution/lrp/lrp.py
@@ -20,17 +20,13 @@ class LRP(GradientAttribution):
     def __init__(
         self,
         rule_mapper: Callable[[str, nn.Module], Rule | None],
-        init_targets: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
-        init_grads: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
-        additional_init_keys: Optional[List[UnraveledKey]] = None,
         warn_on_missing_rule: bool = True,
         skip_modules: Optional[Callable[[str, nn.Module], bool]] = None,
+        **kwargs,
     ):
+        kwargs["multiply_by_inputs"] = False
         super().__init__(
-            init_targets=init_targets,
-            init_grads=init_grads,
-            multiply_by_inputs=False,
-            additional_init_keys=additional_init_keys,
+            **kwargs,
         )
         self._rule_mapper = rule_mapper
         self._warn_on_missing_rule = warn_on_missing_rule

--- a/src/tdhook/metrics.py
+++ b/src/tdhook/metrics.py
@@ -49,8 +49,8 @@ class InfidelityMetric:
                 )
 
                 # Model output change
-                original_output = module(original_data)["output"]
-                perturbed_output = module(perturbed_data)["output"]
+                original_output = module(original_data)[("_mod_out", "output")]
+                perturbed_output = module(perturbed_data)[("_mod_out", "output")]
                 output_change = (original_output - perturbed_output).sum(
                     dim=tuple(range(n_batch_dims, original_output.dim()))
                 )

--- a/src/tdhook/module.py
+++ b/src/tdhook/module.py
@@ -71,6 +71,14 @@ def td_grad(
     return TensorDict(dict(zip(inputs.keys(True, True), tup_grads)), batch_size=inputs.batch_size)
 
 
+def flatten_reshape_call(module: TensorDictModuleBase, td: TensorDict) -> TensorDict:
+    return module(td.flatten()).reshape(td.shape)
+
+
+def flatten_select_reshape_call(module: TensorDictModuleBase, td: TensorDict) -> TensorDict:
+    return module(td.flatten()).select(*module.out_keys).reshape(td.shape)
+
+
 class FunctionModule(TensorDictModuleBase):
     def __init__(
         self, td_fn: Callable[[TensorDict], TensorDict], in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
@@ -82,6 +90,9 @@ class FunctionModule(TensorDictModuleBase):
 
     def forward(self, tensordict: TensorDict) -> TensorDict:
         return self._td_fn(tensordict)
+
+    def __repr__(self):
+        return f"FunctionModule(in_keys={self.in_keys}, out_keys={self.out_keys}, td_fn={self._td_fn})"
 
 
 class HookedModuleRun:

--- a/tests/attribution/test_gradient.py
+++ b/tests/attribution/test_gradient.py
@@ -79,7 +79,7 @@ class TestGradientAttribution:
     @pytest.mark.parametrize(
         "batch_size",
         (
-            tuple(),
+            (),
             (3,),
             (2, 3),
         ),

--- a/tests/attribution/test_gradient.py
+++ b/tests/attribution/test_gradient.py
@@ -138,7 +138,7 @@ class TestGradientAttribution:
     @pytest.mark.parametrize(
         "batch_size",
         (
-            tuple(),
+            (),
             (3,),
             (2, 3),
         ),

--- a/tests/attribution/test_gradient.py
+++ b/tests/attribution/test_gradient.py
@@ -2,6 +2,8 @@
 Test gradient attribution.
 """
 
+from typing import Tuple
+
 import torch
 import torch.nn as nn
 import pytest
@@ -41,6 +43,27 @@ def get_sequential_conv_module(seed: int):
     )
 
 
+def get_multitarget_module(seed: int):
+    torch.manual_seed(seed)
+    return nn.Sequential(
+        nn.Linear(10, 10),
+        nn.ReLU(),
+        nn.Linear(10, 10),
+        nn.ReLU(),
+        nn.Linear(10, 8),
+    )
+
+
+class WrapSum(nn.Module):
+    def __init__(self, module: nn.Module, targets: Tuple[int, ...]):
+        super().__init__()
+        self.module = module
+        self.targets = targets
+
+    def forward(self, x):
+        return self.module(x)[:, self.targets].sum(dim=-1)
+
+
 class TestGradientAttribution:
     @pytest.mark.parametrize(
         "factory",
@@ -53,17 +76,30 @@ class TestGradientAttribution:
         "absolute",
         (True, False),
     )
-    def test_saliency(self, factory, absolute):
+    @pytest.mark.parametrize(
+        "batch_size",
+        (
+            tuple(),
+            (3,),
+            (2, 3),
+        ),
+    )
+    def test_saliency(self, factory, absolute, batch_size):
         get_module, input_shape = factory
         module = get_module(seed=0)
-        input_data = torch.randn(input_shape, requires_grad=True)
+        input_data = torch.randn(*batch_size, *input_shape, requires_grad=True)
 
         captum_attributor = CaptumSaliency(module)
-        attributions = captum_attributor.attribute(input_data, abs=absolute)
+        if len(batch_size) > 0:
+            attributions = captum_attributor.attribute(
+                input_data.flatten(end_dim=len(batch_size) - 1), abs=absolute
+            ).reshape(input_data.shape)
+        else:
+            attributions = captum_attributor.attribute(input_data, abs=absolute)
 
         tdhook_context_factory = Saliency(absolute=absolute)
         with tdhook_context_factory.prepare(module) as hooked_module:
-            output = hooked_module(TensorDict({"input": input_data}))
+            output = hooked_module(TensorDict({"input": input_data}, batch_size=batch_size))
 
         torch.testing.assert_close(output.get(("attr", "input")), attributions)
 
@@ -99,35 +135,83 @@ class TestGradientAttribution:
         "multiply_by_inputs",
         (True, False),
     )
-    def test_integrated_gradients(self, factory, multiply_by_inputs):
+    @pytest.mark.parametrize(
+        "batch_size",
+        (
+            tuple(),
+            (3,),
+            (2, 3),
+        ),
+    )
+    def test_integrated_gradients(self, factory, multiply_by_inputs, batch_size):
         get_module, input_shape = factory
         module = get_module(seed=0)
-        input_data = torch.randn(input_shape).unsqueeze(0)
+        input_data = torch.randn(*batch_size, *input_shape)
         baseline = torch.zeros_like(input_data)
 
         captum_attributor = CaptumIntegratedGradients(module, multiply_by_inputs=multiply_by_inputs)
-        attributions, convergence_delta = captum_attributor.attribute(
-            input_data, baseline, return_convergence_delta=True
-        )
+        if len(batch_size) > 0:
+            attributions, convergence_delta = captum_attributor.attribute(
+                input_data.flatten(end_dim=len(batch_size) - 1),
+                baseline.flatten(end_dim=len(batch_size) - 1),
+                return_convergence_delta=True,
+            )
+            attributions = attributions.reshape(input_data.shape)
+            convergence_delta = convergence_delta.reshape(batch_size)
+        else:
+            attributions, convergence_delta = captum_attributor.attribute(
+                input_data.unsqueeze(0), baseline.unsqueeze(0), return_convergence_delta=True
+            )
+            attributions = attributions.squeeze(0)
+            convergence_delta = convergence_delta.squeeze(0)
 
         tdhook_context_factory = IntegratedGradients(
             compute_convergence_delta=True, multiply_by_inputs=multiply_by_inputs
         )
         with tdhook_context_factory.prepare(module) as hooked_module:
-            output = hooked_module(TensorDict({"input": input_data, ("baseline", "input"): baseline}, batch_size=1))
+            output = hooked_module(
+                TensorDict({"input": input_data, ("baseline", "input"): baseline}, batch_size=batch_size)
+            )
 
         torch.testing.assert_close(output.get(("attr", "input")), attributions)
         torch.testing.assert_close(output.get("convergence_delta"), convergence_delta)
 
-    def test_requires_batched_hook(self):
-        module = nn.Linear(10, 1)
-        input_data = torch.randn(10)
+    @pytest.mark.parametrize(
+        "multiply_by_inputs",
+        (True, False),
+    )
+    def test_multitarget_integrated_gradients(self, multiply_by_inputs):
+        module = get_multitarget_module(seed=0)
+        captum_module = WrapSum(module, (4, 7))
+        input_data = torch.randn(3, 10)
         baseline = torch.zeros_like(input_data)
 
-        with pytest.raises(NotImplementedError):
-            tdhook_context_factory = IntegratedGradients(compute_convergence_delta=True)
-            with tdhook_context_factory.prepare(module) as hooked_module:
-                hooked_module(TensorDict({"input": input_data, ("baseline", "input"): baseline}))
+        captum_attributor = CaptumIntegratedGradients(captum_module, multiply_by_inputs=multiply_by_inputs)
+        attributions, convergence_delta = captum_attributor.attribute(
+            input_data, baseline, return_convergence_delta=True
+        )
+
+        sum_tdhook_context_factory = IntegratedGradients(
+            compute_convergence_delta=True, multiply_by_inputs=multiply_by_inputs
+        )
+        with sum_tdhook_context_factory.prepare(captum_module) as hooked_module:
+            sum_output = hooked_module(
+                TensorDict({"input": input_data, ("baseline", "input"): baseline}, batch_size=3)
+            )
+
+        torch.testing.assert_close(sum_output.get(("attr", "input")), attributions)
+        torch.testing.assert_close(sum_output.get("convergence_delta"), convergence_delta)
+
+        tdhook_context_factory = IntegratedGradients(
+            compute_convergence_delta=True,
+            init_attr_targets=lambda td, _: td.apply(lambda t: t[..., (4, 7)]),
+            multiply_by_inputs=multiply_by_inputs,
+        )
+        with tdhook_context_factory.prepare(module) as hooked_module:
+            output = hooked_module(TensorDict({"input": input_data, ("baseline", "input"): baseline}, batch_size=3))
+
+        torch.testing.assert_close(output.get(("attr", "input")), attributions)
+        torch.testing.assert_close(output.get("convergence_delta"), convergence_delta)
 
 
 class TestGradientAttributionHelpers:
@@ -148,3 +232,25 @@ class TestGradientAttributionHelpers:
 
         for tdhook_tensor, captum_tensor in zip(tdhook_tensors, captum_tensors):
             assert tdhook_tensor == captum_tensor
+
+
+class TestInitAttrTargetsWithLabels:
+    """Test the init_attr_targets_with_labels static method."""
+
+    @pytest.mark.parametrize("batch_size", [(), (2,), (3, 2)])
+    @pytest.mark.parametrize("step_size", [25, 50])
+    def test_init_attr_targets_with_labels_shapes(self, batch_size, step_size):
+        """Test that init_attr_targets_with_labels returns correct shapes."""
+        full_batch_size = batch_size + (step_size,)
+        outputs = TensorDict({"output": torch.randn(*full_batch_size, 15)}, batch_size=full_batch_size)
+
+        additional_init_tensors = TensorDict(
+            {("label", "output"): torch.randint(0, 15, batch_size)}, batch_size=batch_size
+        )
+
+        result = IntegratedGradients.init_attr_targets_with_labels(outputs, additional_init_tensors, ["output"])
+
+        assert isinstance(result, TensorDict)
+        assert result.batch_size == full_batch_size
+        assert "output" in result
+        assert result["output"].shape == full_batch_size

--- a/tests/attribution/test_lrp.py
+++ b/tests/attribution/test_lrp.py
@@ -249,7 +249,15 @@ class TestRules:
         handle = RemovableRuleHandle(rule, module)
         handle._module_ref = lambda: None
 
-        handle.remove()
+        # Should not raise and should leave handle state unchanged
+        try:
+            handle.remove()
+        except Exception as exc:
+            assert False, f"remove() raised an exception when module is None: {exc}"
+
+        # Assert that rule and _module_ref are still set
+        assert handle.rule is rule
+        assert handle._module_ref() is None
 
     def test_pass_rule_forward_errors(self):
         """Test PassRule.forward() error cases."""

--- a/tests/attribution/test_lrp.py
+++ b/tests/attribution/test_lrp.py
@@ -211,7 +211,7 @@ class TestRules:
 
         lrp = LRP(
             rule_mapper=tdhook_mapper,
-            init_grads=lambda *_: TensorDict({"output": out_relevance}),
+            init_attr_grads=lambda *_: TensorDict({"output": out_relevance}),
             skip_modules=LRP.default_skip,
         )
         with lrp.prepare(tdhook_module) as hooked_module:
@@ -223,7 +223,7 @@ class TestRules:
             zennit_output.backward(out_relevance)
             zennit_in_relevance = zennit_input.grad
 
-        torch.testing.assert_close(original_output, tdhook_output.get("output"))
+        torch.testing.assert_close(original_output, tdhook_output.get(("_mod_out", "output")))
         torch.testing.assert_close(tdhook_in_relevance, zennit_in_relevance)
 
     def test_skip_modules_no_warning(self):

--- a/tests/attribution/test_lrp.py
+++ b/tests/attribution/test_lrp.py
@@ -249,14 +249,13 @@ class TestRules:
         handle = RemovableRuleHandle(rule, module)
         handle._module_ref = lambda: None
 
-        # Should not raise and should leave handle state unchanged
         try:
+            handle.remove()
             handle.remove()
         except Exception as exc:
             assert False, f"remove() raised an exception when module is None: {exc}"
 
-        # Assert that rule and _module_ref are still set
-        assert handle.rule is rule
+        assert handle._rule is rule
         assert handle._module_ref() is None
 
     def test_pass_rule_forward_errors(self):
@@ -269,12 +268,7 @@ class TestRules:
                 self.linear = nn.Linear(10, 10)
 
             def forward(self, *inputs):
-                if len(inputs) == 2:
-                    out1 = self.linear(inputs[0])
-                    out2 = self.linear(inputs[1])
-                    return out1, out2
-                else:
-                    return tuple(self.linear(inp) for inp in inputs)
+                return tuple(self.linear(inp) for inp in inputs)
 
         rule = PassRule()
         module = MultiOutputModule()

--- a/tests/attribution/test_lrp.py
+++ b/tests/attribution/test_lrp.py
@@ -18,6 +18,10 @@ from tdhook.attribution.lrp.rules import (
     WSquareRule,
     EpsilonPlus,
     PassRule,
+    UniformEpsilonRule,
+    UniformRule,
+    StopRule,
+    SoftmaxEpsilonRule,
     raise_for_unconserved_rel_factory,
 )
 from tdhook.attribution import LRP
@@ -234,3 +238,279 @@ class TestRules:
             warnings.simplefilter("error")
             with clean_lrp.prepare(module):
                 pass
+
+    def test_removable_rule_handle_module_none(self):
+        """Test RemovableRuleHandle.remove() when module reference is None."""
+        from tdhook.attribution.lrp.rules import RemovableRuleHandle
+
+        rule = EpsilonRule(epsilon=1e-6)
+        module = get_linear_module(seed=0)
+
+        handle = RemovableRuleHandle(rule, module)
+        handle._module_ref = lambda: None
+
+        handle.remove()
+
+    def test_pass_rule_forward_errors(self):
+        """Test PassRule.forward() error cases."""
+        from tdhook.attribution.lrp.rules import PassRule
+
+        class MultiOutputModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(10, 10)
+
+            def forward(self, *inputs):
+                if len(inputs) == 2:
+                    out1 = self.linear(inputs[0])
+                    out2 = self.linear(inputs[1])
+                    return out1, out2
+                else:
+                    return tuple(self.linear(inp) for inp in inputs)
+
+        rule = PassRule()
+        module = MultiOutputModule()
+        rule.register(module)
+
+        with pytest.raises(ValueError, match="PassRule requires the number of inputs and outputs to be the same"):
+
+            class FixedOutputModule(nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.linear = nn.Linear(10, 10)
+
+                def forward(self, *inputs):
+                    return self.linear(inputs[0]), self.linear(inputs[0])
+
+            rule2 = PassRule()
+            module2 = FixedOutputModule()
+            rule2.register(module2)
+
+            module2(torch.randn(10), torch.randn(10), torch.randn(10))
+
+        with pytest.raises(ValueError, match="Input.*and output.*have different shapes"):
+
+            class ShapeMismatchModule(nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.linear1 = nn.Linear(5, 10)
+                    self.linear2 = nn.Linear(10, 10)
+
+                def forward(self, x1, x2):
+                    return self.linear1(x1), self.linear2(x2)
+
+            rule3 = PassRule()
+            module3 = ShapeMismatchModule()
+            rule3.register(module3)
+
+            module3(torch.randn(5), torch.randn(10))
+
+        rule.unregister(module)
+
+    def test_uniform_epsilon_rule(self):
+        """Test UniformEpsilonRule backward pass."""
+
+        rule = UniformEpsilonRule(epsilon=1e-6)
+        module = get_linear_module(seed=0)
+        rule.register(module)
+
+        input_tensor = torch.randn(10, requires_grad=True)
+        output = module(input_tensor)
+        out_relevance = torch.randn_like(output)
+
+        output.backward(out_relevance)
+
+        rule.unregister(module)
+
+    def test_wsquare_rule(self):
+        """Test WSquareRule forward and backward passes."""
+        from tdhook.attribution.lrp.rules import WSquareRule
+
+        rule = WSquareRule(stabilizer=1e-6)
+        module = get_linear_module(seed=0)
+        rule.register(module)
+
+        input_tensor = torch.randn(10, requires_grad=True)
+        output = module(input_tensor)
+        out_relevance = torch.randn_like(output)
+
+        # This should work without errors
+        output.backward(out_relevance)
+
+        rule.unregister(module)
+
+    def test_alpha_beta_rule_validation(self):
+        """Test AlphaBetaRule parameter validation."""
+        from tdhook.attribution.lrp.rules import AlphaBetaRule
+
+        with pytest.raises(ValueError, match="Both alpha and beta parameters must be non-negative"):
+            AlphaBetaRule(alpha=-1.0, beta=1.0)
+
+        with pytest.raises(ValueError, match="Both alpha and beta parameters must be non-negative"):
+            AlphaBetaRule(alpha=1.0, beta=-1.0)
+
+        with pytest.raises(ValueError, match="The difference of parameters alpha - beta must equal 1"):
+            AlphaBetaRule(alpha=2.0, beta=0.5)
+
+    def test_alpha_beta_rule_multiple_inputs(self):
+        """Test AlphaBetaRule with multiple inputs (should raise NotImplementedError)."""
+        from tdhook.attribution.lrp.rules import AlphaBetaRule
+
+        class MultiInputModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(10, 10)
+
+            def forward(self, *inputs):
+                return self.linear(inputs[0])
+
+        rule = AlphaBetaRule(alpha=2.0, beta=1.0)
+        module = MultiInputModule()
+        rule.register(module)
+
+        with pytest.raises(NotImplementedError, match="AlphaBetaRule does not support multiple inputs"):
+            module(torch.randn(10), torch.randn(10))
+
+        rule.unregister(module)
+
+    def test_softmax_epsilon_rule(self):
+        """Test SoftmaxEpsilonRule backward pass."""
+
+        rule = SoftmaxEpsilonRule(epsilon=1e-6)
+        module = get_linear_module(seed=0)
+        rule.register(module)
+
+        input_tensor = torch.randn(10, requires_grad=True)
+        output = module(input_tensor)
+        out_relevance = torch.randn_like(output)
+
+        # This should work without errors
+        output.backward(out_relevance)
+
+        rule.unregister(module)
+
+    def test_uniform_rule(self):
+        """Test UniformRule forward and backward passes."""
+
+        rule = UniformRule()
+        module = get_linear_module(seed=0)
+        rule.register(module)
+
+        input_tensor = torch.randn(10, requires_grad=True)
+        output = module(input_tensor)
+        out_relevance = torch.randn_like(output)
+
+        # This should work without errors
+        output.backward(out_relevance)
+
+        rule.unregister(module)
+
+    def test_stop_rule(self):
+        """Test StopRule forward and backward passes."""
+
+        rule = StopRule()
+        module = get_linear_module(seed=0)
+        rule.register(module)
+
+        input_tensor = torch.randn(10, requires_grad=True)
+        output = module(input_tensor)
+        out_relevance = torch.randn_like(output)
+
+        # This should work without errors
+        output.backward(out_relevance)
+
+        rule.unregister(module)
+
+    def test_base_rule_mapper_call(self):
+        """Test BaseRuleMapper._call() method."""
+        from tdhook.attribution.lrp.rules import BaseRuleMapper
+        from tdhook.attribution.lrp.layers import Sum
+
+        mapper = BaseRuleMapper()
+
+        activation_module = nn.ReLU()
+        rule = mapper._call("relu", activation_module)
+        assert rule is not None
+
+        bn_module = nn.BatchNorm1d(10)
+        rule = mapper._call("bn", bn_module)
+        assert rule is not None
+
+        sum_module = Sum()
+        rule = mapper._call("sum", sum_module)
+        assert rule is not None
+
+        avgpool_module = nn.AdaptiveAvgPool1d(1)
+        rule = mapper._call("avgpool", avgpool_module)
+        assert rule is not None
+
+    def test_epsilon_plus_call(self):
+        """Test EpsilonPlus._call() method."""
+        from tdhook.attribution.lrp.rules import EpsilonPlus
+
+        mapper = EpsilonPlus()
+
+        conv_module = nn.Conv1d(10, 10, 3)
+        rule = mapper._call("conv", conv_module)
+        assert rule is not None
+
+        linear_module = nn.Linear(10, 10)
+        rule = mapper._call("linear", linear_module)
+        assert rule is not None
+
+    def test_raise_for_unconserved_rel_factory_error_handling(self):
+        """Test raise_for_unconserved_rel_factory error handling."""
+        from tdhook.attribution.lrp.rules import raise_for_unconserved_rel_factory
+
+        module = get_linear_module(seed=0)
+
+        hook = raise_for_unconserved_rel_factory(atol=1e-10, rtol=1e-10)
+
+        in_relevances = (torch.randn(10), torch.randn(10))
+        out_relevances = (torch.randn(10),)
+
+        with pytest.raises(RuntimeError, match="Unconserved relevance"):
+            hook(module, in_relevances, out_relevances)
+
+        in_relevances = torch.randn(10)
+        out_relevances = torch.randn(10)
+
+        with pytest.raises(RuntimeError, match="Unconserved relevance"):
+            hook(module, in_relevances, out_relevances)
+
+    def test_epsilon_rule_no_input_grad(self):
+        """Test EpsilonRule when no inputs require gradients."""
+        from tdhook.attribution.lrp.rules import EpsilonRule
+
+        rule = EpsilonRule(epsilon=1e-6)
+        module = get_linear_module(seed=0)
+        rule.register(module)
+
+        input_tensor = torch.randn(10, requires_grad=False)
+        output = module(input_tensor)
+
+        assert not output.requires_grad
+
+        rule.unregister(module)
+
+    def test_epsilon_plus_super_call(self):
+        """Test EpsilonPlus._call() when super()._call() is invoked."""
+        from tdhook.attribution.lrp.rules import EpsilonPlus
+
+        mapper = EpsilonPlus()
+
+        activation_module = nn.ReLU()
+        rule = mapper._call("relu", activation_module)
+        assert rule is not None
+
+        class CustomModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.param = nn.Parameter(torch.randn(10))
+
+            def forward(self, x):
+                return x + self.param
+
+        custom_module = CustomModule()
+        rule = mapper._call("custom", custom_module)
+        assert rule is None


### PR DESCRIPTION
## What does this PR do?

Key insights about the PR.

## Linked Issues

- Closes #?
- #?

## Summary by Sourcery

Add support for multi-dimensional batch sizes in the attribution pipeline, refactor the GradientAttribution API, extend LRP and IntegratedGradients with new initialization and utility methods, unify and enhance benchmarking scripts’ argument parsing, and expand tests and CI coverage.

New Features:
- Support multi-dimensional batch shapes in Saliency and IntegratedGradients attribution factories
- Introduce key pipeline helpers flatten_select_reshape_call and init_attr_targets_with_labels for flexible target initialization
- Unify benchmark scripts to use a standardized parse_args and main() signature
- Add new tests covering LRP rule behaviours and error cases

Bug Fixes:
- Correct output key handling in LRP and metrics to use ('_mod_out','output')
- Ensure init_attr_* hooks enforce consistent batch sizes and API renames init_grads to init_attr_grads

Enhancements:
- Refactor GradientAttribution._prepare_module to a more modular pipeline with clearer init_attr_* hooks
- Improve FunctionModule with a __repr__ and add flatten_reshape_call helper

CI:
- Add Codecov upload steps for coverage and test results in GitHub Actions

Tests:
- Parameterize multi-batch tests for Saliency and IntegratedGradients
- Extend LRP rule tests for PassRule, EpsilonRule variants, AlphaBetaRule validations, and more