### PR TITLE
[BugFix] Fixed relative path support

### DIFF
--- a/src/tdhook/attribution/activation_maximisation.py
+++ b/src/tdhook/attribution/activation_maximisation.py
@@ -54,7 +54,11 @@ class ActivationMaximisation(HookingContextFactory):
         self._hooked_module_kwargs["relative_path"] = "td_module.module[1]._td_module"
 
     def _prepare_module(
-        self, module: TensorDictModuleBase, in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
+        self,
+        module: TensorDictModuleBase,
+        in_keys: List[UnraveledKey],
+        out_keys: List[UnraveledKey],
+        extra_relative_path: str,
     ) -> TensorDictModuleBase:
         working_in_keys = [("_working", in_key) for in_key in in_keys]
         attr_keys = [(self._attribution_key, in_key) for in_key in in_keys]

--- a/src/tdhook/attribution/gradient_helpers/common.py
+++ b/src/tdhook/attribution/gradient_helpers/common.py
@@ -47,7 +47,7 @@ class GradientAttribution(HookingContextFactory, metaclass=ABCMeta):
         self._additional_init_keys = additional_init_keys or []
         self._attr_key = attribution_key
         self._clean_intermediate_keys = clean_intermediate_keys
-        self._hooked_module_kwargs["relative_path"] = "td_module.module[2]._td_module.module"
+        self._hooked_module_kwargs["relative_path"] = "td_module.module[2]._td_module"
 
     def _prepare_module(
         self, module: TensorDictModuleBase, in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]

--- a/src/tdhook/attribution/gradient_helpers/common.py
+++ b/src/tdhook/attribution/gradient_helpers/common.py
@@ -50,7 +50,11 @@ class GradientAttribution(HookingContextFactory, metaclass=ABCMeta):
         self._hooked_module_kwargs["relative_path"] = "td_module.module[2]._td_module"
 
     def _prepare_module(
-        self, module: TensorDictModuleBase, in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
+        self,
+        module: TensorDictModuleBase,
+        in_keys: List[UnraveledKey],
+        out_keys: List[UnraveledKey],
+        extra_relative_path: str,
     ) -> TensorDictModuleBase:
         register_in_keys = [("_register_in", in_key) for in_key in in_keys]
         mod_in_keys = [("_mod_in", in_key) for in_key in in_keys]
@@ -221,13 +225,19 @@ class GradientAttributionWithBaseline(GradientAttribution):
         self._multiply_by_inputs = multiply_by_inputs
 
     def _prepare_module(
-        self, module: TensorDictModuleBase, in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
+        self,
+        module: TensorDictModuleBase,
+        in_keys: List[UnraveledKey],
+        out_keys: List[UnraveledKey],
+        extra_relative_path: str,
     ) -> TensorDictModuleBase:
         n_in_keys = len(in_keys)
         register_in_keys = [("_register_in", in_key) for in_key in in_keys]
         attr_keys = [(self._attr_key, in_key) for in_key in in_keys]
         baseline_keys = [(self._baseline_key, in_key) for in_key in in_keys]
-        (_, register_inputs, module_call, attributor, *_) = super()._prepare_module(module, in_keys, out_keys)
+        (_, register_inputs, module_call, attributor, *_) = super()._prepare_module(
+            module, in_keys, out_keys, extra_relative_path
+        )
 
         modules = [
             FunctionModule(

--- a/src/tdhook/attribution/lrp.py
+++ b/src/tdhook/attribution/lrp.py
@@ -30,7 +30,11 @@ class LRP(GradientAttribution):
         self._skip_modules = skip_modules
 
     def _prepare_module(
-        self, module: TensorDictModuleBase, in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
+        self,
+        module: TensorDictModuleBase,
+        in_keys: List[UnraveledKey],
+        out_keys: List[UnraveledKey],
+        extra_relative_path: str,
     ) -> TensorDictModuleBase:
         rule_map = {}
         for name, child in module.named_modules():
@@ -43,12 +47,16 @@ class LRP(GradientAttribution):
             elif self._warn_on_missing_rule:
                 warn(f"No rule found for module `{name}` ({type(child).__name__})")
         module._rule_map = rule_map
-        return super()._prepare_module(module, in_keys, out_keys)
+        return super()._prepare_module(module, in_keys, out_keys, extra_relative_path)
 
     def _restore_module(
-        self, module: TensorDictModuleBase, in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
+        self,
+        module: TensorDictModuleBase,
+        in_keys: List[UnraveledKey],
+        out_keys: List[UnraveledKey],
+        extra_relative_path: str,
     ) -> TensorDictModuleBase:
-        module = super()._restore_module(module, in_keys, out_keys)
+        module = super()._restore_module(module, in_keys, out_keys, extra_relative_path)
         for name, child in module.named_modules():
             rule = self._rule_mapper(name, child)
             if rule is not None:

--- a/src/tdhook/contexts.py
+++ b/src/tdhook/contexts.py
@@ -35,8 +35,10 @@ class HookingContext:
 
         if isinstance(module, TensorDictModuleBase):
             self._module = module
+            self._extra_relative_path = ""
         else:
             self._module = TensorDictModule(module, in_keys or ["input"], out_keys or ["output"])
+            self._extra_relative_path = ".module"
 
         self._in_keys = self._module.in_keys
         self._out_keys = self._module.out_keys
@@ -54,6 +56,7 @@ class HookingContext:
 
         prep_module = self._prepare(working_module, self._in_keys, self._out_keys)
         self._hooked_module = self._spawn(prep_module, self)
+        self._hooked_module._relative_path += self._extra_relative_path
         self._handle = self._hook(self._hooked_module)
         return self._hooked_module
 

--- a/src/tdhook/hooks.py
+++ b/src/tdhook/hooks.py
@@ -75,6 +75,11 @@ def _check_hook_signature(hook: Callable, direction: HookDirection):
         raise ValueError(f"Hook ({direction}) must have the signature {expected_params}")
 
 
+def merge_paths(*paths: str) -> str:
+    """Merge multiple paths into a single path."""
+    return ".".join(path for path in paths if path)
+
+
 def resolve_submodule_path(root: nn.Module, key: str):
     """
     Resolve a submodule path that may contain indexing expressions.

--- a/src/tdhook/latent/activation_patching.py
+++ b/src/tdhook/latent/activation_patching.py
@@ -32,7 +32,11 @@ class ActivationPatching(HookingContextFactory):
         self._hooked_module_kwargs["relative_path"] = "td_module.module[0]._td_module"
 
     def _prepare_module(
-        self, module: TensorDictModuleBase, in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
+        self,
+        module: TensorDictModuleBase,
+        in_keys: List[UnraveledKey],
+        out_keys: List[UnraveledKey],
+        extra_relative_path: str,
     ) -> TensorDictModuleBase:
         stored_keys = [f"{m}_output" for m in self._modules_to_patch]
 

--- a/src/tdhook/latent/steering_vectors.py
+++ b/src/tdhook/latent/steering_vectors.py
@@ -66,7 +66,11 @@ class ActivationAddition(HookingContextFactory):
         self._hooked_module_kwargs["relative_path"] = "td_module.module[0]._td_module"
 
     def _prepare_module(
-        self, module: TensorDictModuleBase, in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
+        self,
+        module: TensorDictModuleBase,
+        in_keys: List[UnraveledKey],
+        out_keys: List[UnraveledKey],
+        extra_relative_path: str,
     ) -> TensorDictModuleBase:
         stored_keys = [f"{m}_output" for m in self._modules_to_steer]
         positive_keys = [(self._positive_key, key) for key in stored_keys]

--- a/src/tdhook/modules.py
+++ b/src/tdhook/modules.py
@@ -438,7 +438,7 @@ class HookedModule(TensorDictModuleWrapper):
         self,
         td_module: TensorDictModule,
         hooking_context: Optional["HookingContext"] = None,
-        relative_path: str = "td_module.module",
+        relative_path: str = "td_module",
     ):
         super().__init__(td_module)
         self._hooking_context = hooking_context

--- a/src/tdhook/weights/pruning.py
+++ b/src/tdhook/weights/pruning.py
@@ -12,6 +12,7 @@ from tdhook.contexts import HookingContextFactory, HookingContext
 from tdhook.modules import resolve_submodule_path
 
 from tdhook._types import UnraveledKey
+from tdhook.hooks import merge_paths
 
 
 class PruningContext(HookingContext):
@@ -57,9 +58,7 @@ class Pruning(HookingContextFactory):
         out_keys: List[UnraveledKey],
         extra_relative_path: str,
     ) -> TensorDictModuleBase:
-        root_module = resolve_submodule_path(
-            module, extra_relative_path + ("." + self._relative_path if self._relative_path else "")
-        )
+        root_module = resolve_submodule_path(module, merge_paths(extra_relative_path, self._relative_path))
 
         if self._modules_to_prune is None:
             parameters_to_prune = []

--- a/src/tdhook/weights/pruning.py
+++ b/src/tdhook/weights/pruning.py
@@ -38,7 +38,6 @@ class Pruning(HookingContextFactory):
         amount_to_prune: Optional[float | int] = None,
         modules_to_prune: Optional[Dict[str, Tuple[int, Optional[float]]]] = None,
         skip_modules: Optional[Callable[[str, nn.Module], bool]] = None,
-        relative: bool = True,
         relative_path: Optional[str] = None,
     ):
         if amount_to_prune is None and modules_to_prune is None:
@@ -49,16 +48,18 @@ class Pruning(HookingContextFactory):
         self._amount_to_prune = amount_to_prune
         self._modules_to_prune = modules_to_prune
         self._skip_modules = skip_modules
-        self._relative = relative
-        self._relative_path = relative_path or "module"
+        self._relative_path = relative_path or ""
 
     def _prepare_module(
-        self, module: TensorDictModuleBase, in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
+        self,
+        module: TensorDictModuleBase,
+        in_keys: List[UnraveledKey],
+        out_keys: List[UnraveledKey],
+        extra_relative_path: str,
     ) -> TensorDictModuleBase:
-        if self._relative:
-            root_module = resolve_submodule_path(module, self._relative_path)
-        else:
-            root_module = module
+        root_module = resolve_submodule_path(
+            module, extra_relative_path + ("." + self._relative_path if self._relative_path else "")
+        )
 
         if self._modules_to_prune is None:
             parameters_to_prune = []
@@ -66,7 +67,7 @@ class Pruning(HookingContextFactory):
             for name, submodule in root_module.named_modules():
                 if self._skip_modules and self._skip_modules(name, submodule):
                     continue
-                for param_name, param in submodule.named_parameters():
+                for param_name, param in submodule.named_parameters(recurse=False):
                     importance_score = self._importance_callback(
                         module_key=name, parameter_name=param_name, parameter=param
                     )
@@ -87,7 +88,7 @@ class Pruning(HookingContextFactory):
             for module_key, (dim, amount) in self._modules_to_prune.items():
                 amount = amount or self._amount_to_prune
                 submodule = resolve_submodule_path(root_module, module_key)
-                for param_name, param in submodule.named_parameters():
+                for param_name, param in submodule.named_parameters(recurse=False):
                     importance_scores = self._importance_callback(
                         module_key=module_key, parameter_name=param_name, parameter=param
                     )

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -41,13 +41,21 @@ class PrepFlagFactory(HookingContextFactory):
         self.flag_name = flag_name
 
     def _prepare_module(
-        self, module: TensorDictModule, in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
+        self,
+        module: TensorDictModule,
+        in_keys: List[UnraveledKey],
+        out_keys: List[UnraveledKey],
+        extra_relative_path: str,
     ) -> TensorDictModule:
         setattr(module, self.flag_name, 1)
         return module
 
     def _restore_module(
-        self, module: TensorDictModule, in_keys: List[UnraveledKey], out_keys: List[UnraveledKey]
+        self,
+        module: TensorDictModule,
+        in_keys: List[UnraveledKey],
+        out_keys: List[UnraveledKey],
+        extra_relative_path: str,
     ) -> TensorDictModule:
         delattr(module, self.flag_name)
         return module

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -62,8 +62,8 @@ class PrepFlagFactory(HookingContextFactory):
 
 
 class BadSpawnFactory(HookingContextFactory):
-    def _spawn_hooked_module(self, prep_module, in_keys, out_keys, hooking_context):
-        return super()._spawn_hooked_module(prep_module, in_keys, out_keys, hooking_context)
+    def _spawn_hooked_module(self, prep_module, hooking_context, extra_relative_path):
+        return super()._spawn_hooked_module(prep_module, hooking_context, extra_relative_path)
 
 
 class TestBaseContext:

--- a/tests/weights/test_pruning.py
+++ b/tests/weights/test_pruning.py
@@ -63,6 +63,18 @@ class TestPruning:
             assert not torch.allclose(default_test_model.linear2.weight, original_linear2_weight)
             assert not torch.allclose(default_test_model.linear3.weight, original_linear3_weight)
 
+    def test_custom_relative_path(self, default_test_model):
+        original_linear1_weight = default_test_model.linear1.weight.clone()
+        original_linear2_weight = default_test_model.linear2.weight.clone()
+        original_linear3_weight = default_test_model.linear3.weight.clone()
+
+        pruning = Pruning(importance_callback=_importance_cb_skip_bias, amount_to_prune=0.5, relative_path="linear1")
+        ctx = pruning.prepare(default_test_model)
+        with ctx:
+            assert not torch.allclose(default_test_model.linear1.weight, original_linear1_weight)
+            assert torch.allclose(default_test_model.linear2.weight, original_linear2_weight)
+            assert torch.allclose(default_test_model.linear3.weight, original_linear3_weight)
+
     def test_pruning_modules(self, default_test_model):
         original_linear1_weight = default_test_model.linear1.weight.clone()
         original_linear2_weight = default_test_model.linear2.weight.clone()


### PR DESCRIPTION
## What does this PR do?

Key insights about the PR.

## Linked Issues

- Closes #?
- #?

## Summary by Sourcery

Fix relative path propagation across HookingContext and module wrappers, correct default relative_path values, and refine pruning scope to direct parameters

Bug Fixes:
- Ensure extra_relative_path is correctly appended to module relative paths in HookingContext
- Fix default relative_path prefix for HookedModule to avoid redundant '.module' segments
- Restrict pruning to non-recursive named parameters to prevent unintended pruning

Enhancements:
- Propagate extra_relative_path argument through all _prepare_module and _restore_module calls in contexts and modules
- Update attribution and latent modules to support the new relative path handling

Tests:
- Add test for custom Pruning relative_path to validate scoped pruning