### PR TITLE
[Feature] Expose `HookingContextWithCache` arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ build-backend = "setuptools.build_meta"
 default-groups = ["dev", "docs", "scripts", "notebooks"]
 
 [tool.uv.sources]
-lczerolens = { git = "https://github.com/Xmaster6y/lczerolens", branch = "chores" }
+lczerolens = { git = "https://github.com/Xmaster6y/lczerolens" }
 
 [tool.ruff]
 line-length = 119

--- a/src/tdhook/attribution/grad_cam.py
+++ b/src/tdhook/attribution/grad_cam.py
@@ -10,7 +10,6 @@ import torch
 
 from tdhook._types import UnraveledKey
 from tdhook.attribution.gradient_helpers import GradientAttribution
-from tdhook.contexts import HookingContextWithCache
 
 
 @dataclass
@@ -20,8 +19,6 @@ class DimsConfig:
 
 
 class GradCAM(GradientAttribution):
-    _hooking_context_class = HookingContextWithCache
-
     def __init__(
         self,
         modules_to_attribute: Dict[str, DimsConfig],

--- a/src/tdhook/contexts.py
+++ b/src/tdhook/contexts.py
@@ -93,7 +93,7 @@ class HookingContext:
 
 
 class HookingContextWithCache(HookingContext):
-    def __init__(self, *args, cache: Optional[TensorDict] = None, clear_cache: bool = False, **kwargs):
+    def __init__(self, *args, cache: Optional[TensorDict] = None, clear_cache: bool = True, **kwargs):
         super().__init__(*args, **kwargs)
         self._cache = TensorDict() if cache is None else cache
         self._clear_cache = clear_cache

--- a/src/tdhook/latent/activation_caching.py
+++ b/src/tdhook/latent/activation_caching.py
@@ -22,9 +22,11 @@ class ActivationCaching(HookingContextFactory):
         callback: Optional[Callable] = None,
         directions: Optional[List[HookDirection]] = None,
         use_nested_keys: bool = False,
+        clear_cache: bool = True,
     ):
         super().__init__()
         self._hooking_context_kwargs["cache"] = cache
+        self._hooking_context_kwargs["clear_cache"] = clear_cache
 
         self._key_pattern = key_pattern
         self._relative = relative

--- a/src/tdhook/weights/adapters.py
+++ b/src/tdhook/weights/adapters.py
@@ -4,6 +4,7 @@ Adapters
 
 from typing import Callable, Optional, List, Dict, Tuple
 from torch import nn
+from tensordict import TensorDict
 
 from tdhook.contexts import HookingContextFactory, HookingContextWithCache
 from tdhook.modules import HookedModule
@@ -26,14 +27,18 @@ class Adapters(HookingContextFactory):
         cache_callback: Optional[Callable] = None,
         relative: bool = True,
         directions: Optional[List[HookDirection]] = None,
+        cache: Optional[TensorDict] = None,
+        clear_cache: bool = True,
     ):
         super().__init__()
+        self._hooked_module_kwargs["adapters"] = {k: v[0] for k, v in adapters.items()}
+        self._hooking_context_kwargs["clear_cache"] = clear_cache
+        self._hooking_context_kwargs["cache"] = cache
+
         self._adapters = adapters
         self._cache_callback = cache_callback
         self._relative = relative
         self._directions = directions or ["fwd"]
-
-        self._hooked_module_kwargs["adapters"] = {k: v[0] for k, v in adapters.items()}
 
     def _hook_module(self, module: HookedModule) -> MultiHookHandle:
         cache = module.hooking_context.cache

--- a/uv.lock
+++ b/uv.lock
@@ -1562,7 +1562,7 @@ wheels = [
 [[package]]
 name = "lczerolens"
 version = "0.3.3.dev0"
-source = { git = "https://github.com/Xmaster6y/lczerolens?branch=chores#0f8ea1fccd68118d131c79ab67dec7980e9237a8" }
+source = { git = "https://github.com/Xmaster6y/lczerolens#6da8adc111231215a94d1898214ac78d9b6a7064" }
 dependencies = [
     { name = "onnx2torch" },
     { name = "python-chess" },
@@ -4116,7 +4116,7 @@ scripts = [
     { name = "captum", specifier = ">=0.8.0" },
     { name = "datasets", specifier = ">=4.0.0" },
     { name = "gymnasium", extras = ["mujoco"], specifier = ">=1.2.0" },
-    { name = "lczerolens", git = "https://github.com/Xmaster6y/lczerolens?branch=chores" },
+    { name = "lczerolens", git = "https://github.com/Xmaster6y/lczerolens" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "matplotlib", specifier = ">=3.8.0" },
     { name = "nnsight", specifier = ">=0.4.11" },


### PR DESCRIPTION
## What does this PR do?

Key insights about the PR.

## Linked Issues

- Closes #?
- #?

## Summary by Sourcery

Expose custom cache and cache-clearing options in the hooking context across adapters and activation caching, adjust default cache retention behavior, and clean up project configuration.

New Features:
- Expose `cache` and `clear_cache` parameters in hooking context for adapters and activation caching modules

Enhancements:
- Change default `clear_cache` behavior to true in HookingContextWithCache

Chores:
- Remove branch specification for lczerolens dependency in pyproject.toml
- Remove explicit `_hooking_context_class` override from GradCAM