### PR TITLE
[BugFix] Fix gradient nested key issue

### DIFF
--- a/src/tdhook/attribution/grad_cam.py
+++ b/src/tdhook/attribution/grad_cam.py
@@ -21,6 +21,7 @@ class DimsConfig:
 class GradCAM(GradientAttribution):
     def __init__(
         self,
+        modules_to_attribute: Optional[Dict[str, DimsConfig]],
         use_inputs: bool = True,
         use_outputs: bool = True,
         input_modules: Optional[List[str]] = None,
@@ -34,12 +35,11 @@ class GradCAM(GradientAttribution):
         clean_intermediate_keys: bool = True,
         cache_callback: Optional[Callable] = None,
         absolute: bool = False,
-        modules_to_attribute: Dict[str, DimsConfig] = {},
     ):
         super().__init__(
             use_inputs=False,
             use_outputs=True,
-            input_modules=modules_to_attribute.keys(),
+            input_modules=modules_to_attribute.keys() if modules_to_attribute is not None else None,
             target_modules=None,
             init_attr_targets=init_attr_targets,
             init_attr_inputs=None,

--- a/src/tdhook/attribution/grad_cam.py
+++ b/src/tdhook/attribution/grad_cam.py
@@ -21,15 +21,20 @@ class DimsConfig:
 class GradCAM(GradientAttribution):
     def __init__(
         self,
-        modules_to_attribute: Dict[str, DimsConfig],
+        use_inputs: bool = True,
+        use_outputs: bool = True,
+        input_modules: Optional[List[str]] = None,
+        target_modules: Optional[List[str]] = None,
         init_attr_targets: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
+        init_attr_inputs: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
         init_attr_grads: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
         additional_init_keys: Optional[List[UnraveledKey]] = None,
+        output_grad_callbacks: Optional[Dict[str, Callable]] = None,
         attribution_key: UnraveledKey = "attr",
         clean_intermediate_keys: bool = True,
+        cache_callback: Optional[Callable] = None,
         absolute: bool = False,
-        output_grad_callbacks: Optional[Dict[str, Callable]] = None,
-        **kwargs,
+        modules_to_attribute: Dict[str, DimsConfig] = {},
     ):
         super().__init__(
             use_inputs=False,

--- a/src/tdhook/attribution/gradient_helpers/common.py
+++ b/src/tdhook/attribution/gradient_helpers/common.py
@@ -182,7 +182,7 @@ class GradientAttribution(HookingContextFactory, metaclass=ABCMeta):
         if set(targets.keys(True, True)) != set(init_grads.keys(True, True)):
             raise ValueError("Targets and init_grads must have the same keys")
 
-        for target_key, target in targets.items():
+        for target_key, target in targets.items(True, True):
             if target.grad_fn is None:
                 raise ValueError(f"Target {target_key} has no grad_fn")
 

--- a/src/tdhook/attribution/gradient_helpers/common.py
+++ b/src/tdhook/attribution/gradient_helpers/common.py
@@ -159,7 +159,9 @@ class GradientAttribution(HookingContextFactory, metaclass=ABCMeta):
             inputs = self._init_attr_inputs(inputs, additional_init_tensors)
             if not isinstance(inputs, TensorDict):
                 raise ValueError("init_attr_inputs function must return a TensorDict")
-        cache_in = cache["_cache_in"] if self._input_modules else TensorDict()
+        cache_in = (
+            cache["_cache_in"] if self._input_modules else TensorDict()
+        )  # TODO: we should init cache_in, but we cannot reshape it
 
         targets = td["_mod_out"] if self._use_outputs else TensorDict()
         targets.update(cache["_cache_out"].reshape(cache["_shape"]) if self._target_modules else {})

--- a/src/tdhook/attribution/guided_backpropagation.py
+++ b/src/tdhook/attribution/guided_backpropagation.py
@@ -2,11 +2,12 @@
 Guided Backpropagation
 """
 
-from typing import Callable, Tuple, Type
+from typing import Callable, Tuple, Type, Optional, List, Dict
 import torch
 from torch import nn
 from tensordict import TensorDict
 
+from tdhook._types import UnraveledKey
 from tdhook.modules import HookedModule
 from tdhook.hooks import MultiHookHandle, MultiHookManager, HookFactory, DIRECTION_TO_RETURN
 from tdhook.attribution.gradient_helpers import GradientAttribution
@@ -14,9 +15,36 @@ from tdhook.attribution.gradient_helpers import GradientAttribution
 
 class GuidedBackpropagation(GradientAttribution):
     def __init__(
-        self, *args, multiply_by_inputs: bool = False, classes_to_skip: Tuple[Type[nn.Module], ...] = (), **kwargs
+        self,
+        use_inputs: bool = True,
+        use_outputs: bool = True,
+        input_modules: Optional[List[str]] = None,
+        target_modules: Optional[List[str]] = None,
+        init_attr_targets: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
+        init_attr_inputs: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
+        init_attr_grads: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
+        additional_init_keys: Optional[List[UnraveledKey]] = None,
+        output_grad_callbacks: Optional[Dict[str, Callable]] = None,
+        attribution_key: UnraveledKey = "attr",
+        clean_intermediate_keys: bool = True,
+        cache_callback: Optional[Callable] = None,
+        multiply_by_inputs: bool = False,
+        classes_to_skip: Tuple[Type[nn.Module], ...] = (),
     ):
-        super().__init__(*args, **kwargs)
+        super().__init__(
+            use_inputs=use_inputs,
+            use_outputs=use_outputs,
+            input_modules=input_modules,
+            target_modules=target_modules,
+            init_attr_targets=init_attr_targets,
+            init_attr_inputs=init_attr_inputs,
+            init_attr_grads=init_attr_grads,
+            additional_init_keys=additional_init_keys,
+            output_grad_callbacks=output_grad_callbacks,
+            attribution_key=attribution_key,
+            clean_intermediate_keys=clean_intermediate_keys,
+            cache_callback=cache_callback,
+        )
         self._hook_manager = MultiHookManager(pattern=r".+", classes_to_skip=classes_to_skip)
         self._multiply_by_inputs = multiply_by_inputs
 

--- a/src/tdhook/attribution/integrated_gradients.py
+++ b/src/tdhook/attribution/integrated_gradients.py
@@ -3,7 +3,7 @@ Integrated gradients
 """
 
 import torch
-from typing import List
+from typing import List, Optional, Callable, Dict
 from tensordict import TensorDict, merge_tensordicts
 
 from tdhook.attribution.gradient_helpers.helpers import approximation_parameters
@@ -12,8 +12,43 @@ from tdhook._types import UnraveledKey
 
 
 class IntegratedGradients(GradientAttributionWithBaseline):
-    def __init__(self, method: str = "gausslegendre", n_steps: int = 50, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(
+        self,
+        use_inputs: bool = True,
+        use_outputs: bool = True,
+        input_modules: Optional[List[str]] = None,
+        target_modules: Optional[List[str]] = None,
+        init_attr_targets: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
+        init_attr_inputs: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
+        init_attr_grads: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
+        additional_init_keys: Optional[List[UnraveledKey]] = None,
+        output_grad_callbacks: Optional[Dict[str, Callable]] = None,
+        attribution_key: UnraveledKey = "attr",
+        clean_intermediate_keys: bool = True,
+        cache_callback: Optional[Callable] = None,
+        compute_convergence_delta: bool = False,
+        baseline_key: UnraveledKey = "baseline",
+        multiply_by_inputs: bool = False,
+        method: str = "gausslegendre",
+        n_steps: int = 50,
+    ):
+        super().__init__(
+            use_inputs=use_inputs,
+            use_outputs=use_outputs,
+            input_modules=input_modules,
+            target_modules=target_modules,
+            init_attr_targets=init_attr_targets,
+            init_attr_inputs=init_attr_inputs,
+            init_attr_grads=init_attr_grads,
+            additional_init_keys=additional_init_keys,
+            output_grad_callbacks=output_grad_callbacks,
+            attribution_key=attribution_key,
+            clean_intermediate_keys=clean_intermediate_keys,
+            cache_callback=cache_callback,
+            compute_convergence_delta=compute_convergence_delta,
+            baseline_key=baseline_key,
+            multiply_by_inputs=multiply_by_inputs,
+        )
         self._method = method
         self._n_steps = n_steps
 

--- a/src/tdhook/attribution/lrp.py
+++ b/src/tdhook/attribution/lrp.py
@@ -2,7 +2,7 @@
 LRP
 """
 
-from typing import Callable, Optional, List
+from typing import Callable, Optional, List, Dict
 
 from torch import nn
 from warnings import warn
@@ -18,15 +18,37 @@ from tdhook.hooks import resolve_submodule_path
 class LRP(GradientAttribution):
     def __init__(
         self,
-        rule_mapper: Callable[[str, nn.Module], Rule | None],
+        use_inputs: bool = True,
+        use_outputs: bool = True,
+        input_modules: Optional[List[str]] = None,
+        target_modules: Optional[List[str]] = None,
+        init_attr_targets: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
+        init_attr_inputs: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
+        init_attr_grads: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
+        additional_init_keys: Optional[List[UnraveledKey]] = None,
+        output_grad_callbacks: Optional[Dict[str, Callable]] = None,
+        attribution_key: UnraveledKey = "attr",
+        clean_intermediate_keys: bool = True,
+        cache_callback: Optional[Callable] = None,
+        rule_mapper: Callable[[str, nn.Module], Rule | None] | None = None,
         warn_on_missing_rule: bool = True,
         skip_modules: Optional[Callable[[str, nn.Module], bool]] = None,
-        **kwargs,
     ):
         super().__init__(
-            **kwargs,
+            use_inputs=use_inputs,
+            use_outputs=use_outputs,
+            input_modules=input_modules,
+            target_modules=target_modules,
+            init_attr_targets=init_attr_targets,
+            init_attr_inputs=init_attr_inputs,
+            init_attr_grads=init_attr_grads,
+            additional_init_keys=additional_init_keys,
+            output_grad_callbacks=output_grad_callbacks,
+            attribution_key=attribution_key,
+            clean_intermediate_keys=clean_intermediate_keys,
+            cache_callback=cache_callback,
         )
-        self._rule_mapper = rule_mapper
+        self._rule_mapper = rule_mapper or (lambda name, module: None)
         self._warn_on_missing_rule = warn_on_missing_rule
         self._skip_modules = skip_modules
 

--- a/src/tdhook/attribution/saliency.py
+++ b/src/tdhook/attribution/saliency.py
@@ -2,15 +2,46 @@
 Saliency attribution
 """
 
+from typing import List, Optional, Callable, Dict
 from tensordict import TensorDict
 import torch
 
+from tdhook._types import UnraveledKey
 from tdhook.attribution.gradient_helpers import GradientAttribution
 
 
 class Saliency(GradientAttribution):
-    def __init__(self, *args, absolute: bool = False, multiply_by_inputs: bool = False, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        use_inputs: bool = True,
+        use_outputs: bool = True,
+        input_modules: Optional[List[str]] = None,
+        target_modules: Optional[List[str]] = None,
+        init_attr_targets: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
+        init_attr_inputs: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
+        init_attr_grads: Optional[Callable[[TensorDict, TensorDict], TensorDict]] = None,
+        additional_init_keys: Optional[List[UnraveledKey]] = None,
+        output_grad_callbacks: Optional[Dict[str, Callable]] = None,
+        attribution_key: UnraveledKey = "attr",
+        clean_intermediate_keys: bool = True,
+        cache_callback: Optional[Callable] = None,
+        absolute: bool = False,
+        multiply_by_inputs: bool = False,
+    ):
+        super().__init__(
+            use_inputs=use_inputs,
+            use_outputs=use_outputs,
+            input_modules=input_modules,
+            target_modules=target_modules,
+            init_attr_targets=init_attr_targets,
+            init_attr_inputs=init_attr_inputs,
+            init_attr_grads=init_attr_grads,
+            additional_init_keys=additional_init_keys,
+            output_grad_callbacks=output_grad_callbacks,
+            attribution_key=attribution_key,
+            clean_intermediate_keys=clean_intermediate_keys,
+            cache_callback=cache_callback,
+        )
         self._absolute = absolute
         self._multiply_by_inputs = multiply_by_inputs
 


### PR DESCRIPTION
## What does this PR do?

Key insights about the PR.

## Linked Issues

- Closes #?
- #?

## Summary by Sourcery

Unify and enrich attribution class initialization by exposing nested TensorDict key configuration, output gradient callbacks, caching, and cleaning options, and fix nested key iteration in the common gradient helper.

New Features:
- Extend constructors of IntegratedGradients, Saliency, GuidedBackpropagation, LRP, and GradCAM to accept explicit nested-key parameters, callbacks, caching, and cleaning controls

Bug Fixes:
- Correct iteration over nested keys in gradient helpers to fix missing grad functions for nested targets

Enhancements:
- Provide a default rule_mapper fallback in LRP when no mapping is supplied
- Set a default empty modules_to_attribute in GradCAM