### PR TITLE
[Feature] TwoNN dimension estimator

### DIFF
--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -226,3 +226,17 @@
   year={2024},
   volume={abs/2403.01267},
 }
+
+@article{facco_estimating_2017,
+  title = {Estimating the intrinsic dimension of datasets by a minimal neighborhood information},
+  volume = {7},
+  issn = {2045-2322},
+  url = {https://doi.org/10.1038/s41598-017-11873-y},
+  doi = {10.1038/s41598-017-11873-y},
+  number = {1},
+  journal = {Scientific Reports},
+  author = {Facco, Elena and d'Errico, Maria and Rodriguez, Alex and Laio, Alessandro},
+  month = sep,
+  year = {2017},
+  pages = {12140},
+}

--- a/src/tdhook/latent/__init__.py
+++ b/src/tdhook/latent/__init__.py
@@ -4,6 +4,7 @@ Module for latent methods.
 
 from .activation_caching import ActivationCaching
 from .activation_patching import ActivationPatching
+from .dimension_estimation import TwoNnDimensionEstimator
 from .probing import Probing
 from .steering_vectors import SteeringVectors, ActivationAddition
 
@@ -13,6 +14,7 @@ __all__ = [
     "ActivationPatching",
     "Probing",
     "SteeringVectors",
+    "TwoNnDimensionEstimator",
 ]
 
 # TODO: Implement ATP*

--- a/src/tdhook/latent/dimension_estimation/__init__.py
+++ b/src/tdhook/latent/dimension_estimation/__init__.py
@@ -1,0 +1,9 @@
+"""
+Intrinsic dimension estimation methods.
+"""
+
+from .twonn import TwoNnDimensionEstimator
+
+__all__ = [
+    "TwoNnDimensionEstimator",
+]

--- a/src/tdhook/latent/dimension_estimation/twonn.py
+++ b/src/tdhook/latent/dimension_estimation/twonn.py
@@ -45,19 +45,15 @@ class TwoNnDimensionEstimator(TensorDictModuleBase):
                 ys.append(y_i)
         td[self.out_key] = torch.stack(dims).reshape(batch_shape)
         if self.return_xy:
-            if flat.shape[0] == 1:
-                td[f"{self.out_key}_x"] = xs[0]
-                td[f"{self.out_key}_y"] = ys[0]
-            else:
-                max_len = data.shape[-2] - 1
-                x_padded = torch.stack(
-                    [torch.nn.functional.pad(x_i, (0, max_len - len(x_i)), value=float("nan")) for x_i in xs]
-                )
-                y_padded = torch.stack(
-                    [torch.nn.functional.pad(y_i, (0, max_len - len(y_i)), value=float("nan")) for y_i in ys]
-                )
-                td[f"{self.out_key}_x"] = x_padded.reshape(*batch_shape, max_len)
-                td[f"{self.out_key}_y"] = y_padded.reshape(*batch_shape, max_len)
+            max_len = data.shape[-2] - 1
+            x_padded = torch.stack(
+                [torch.nn.functional.pad(x_i, (0, max_len - len(x_i)), value=float("nan")) for x_i in xs]
+            )
+            y_padded = torch.stack(
+                [torch.nn.functional.pad(y_i, (0, max_len - len(y_i)), value=float("nan")) for y_i in ys]
+            )
+            td[f"{self.out_key}_x"] = x_padded.reshape(*batch_shape, max_len)
+            td[f"{self.out_key}_y"] = y_padded.reshape(*batch_shape, max_len)
         return td
 
     def __repr__(self):

--- a/src/tdhook/latent/dimension_estimation/twonn.py
+++ b/src/tdhook/latent/dimension_estimation/twonn.py
@@ -1,0 +1,84 @@
+from textwrap import indent
+
+import torch
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModuleBase
+
+
+class TwoNnDimensionEstimator(TensorDictModuleBase):
+    """
+    Intrinsic dimension estimation via the Two NN algorithm :cite:`facco_estimating_2017`.
+
+    Reads a data tensor from the input TensorDict, flattens it to 2D (samples × features),
+    and writes the estimated intrinsic dimension to the output key.
+    """
+
+    def __init__(
+        self,
+        in_key: str = "data",
+        out_key: str = "dimension",
+        return_xy: bool = False,
+    ):
+        super().__init__()
+        self._in_key = in_key
+        self._out_key = out_key
+        self._return_xy = return_xy
+        self.in_keys = [in_key]
+        if return_xy:
+            self.out_keys = [out_key, f"{out_key}_x", f"{out_key}_y"]
+        else:
+            self.out_keys = [out_key]
+
+    def forward(self, td: TensorDict) -> TensorDict:
+        data = td[self._in_key]
+        data = data.flatten(0, -2)
+        if data.shape[0] < 3:
+            raise ValueError("At least 3 points required for Two NN dimension estimation")
+        d, x, y = _twonn(data)
+        td[self._out_key] = d.reshape(())
+        if self._return_xy:
+            td[f"{self._out_key}_x"] = x
+            td[f"{self._out_key}_y"] = y
+        return td
+
+    def __repr__(self):
+        fields = indent(
+            f"in_key={self._in_key!r},\nout_key={self._out_key!r},\nreturn_xy={self._return_xy}",
+            4 * " ",
+        )
+        return f"{type(self).__name__}(\n{fields})"
+
+
+def _twonn(data: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Compute Two NN intrinsic dimension. data: (N, D). Returns (d, x, y)."""
+    dist = torch.cdist(data, data, p=2)
+    dist = dist.clone()
+    dist.fill_diagonal_(float("inf"))  # exclude self from nearest neighbors
+    sorted_dist, _ = torch.sort(dist, dim=1)
+    r1 = sorted_dist[:, 0]
+    r2 = sorted_dist[:, 1]
+
+    # Filter out points where r1 or r2 is 0 (duplicates)
+    valid = (r1 > 0) & (r2 > 0)
+    if valid.sum() < 3:
+        raise ValueError("Too many duplicate or degenerate points for Two NN dimension estimation")
+
+    mu = (r2 / r1)[valid]
+    N_valid = mu.shape[0]
+
+    sorted_indices = torch.argsort(mu)
+    mu_sorted = mu[sorted_indices]
+
+    # Empirical CDF F = rank/N; exclude F=1 to avoid log(0)
+    rank_1based = torch.arange(1, N_valid, device=data.device, dtype=data.dtype)
+    one_minus_F = 1 - rank_1based / N_valid
+    x = torch.log(mu_sorted[:-1])
+    y = -torch.log(one_minus_F)
+    if len(x) < 3:
+        raise ValueError("Insufficient valid points for linear fit")
+
+    x_col = x.unsqueeze(1)
+    d = torch.linalg.lstsq(x_col, y.unsqueeze(1), rcond=None, driver=None).solution.squeeze()
+    d = d.float()
+
+    return d, x, y

--- a/src/tdhook/latent/representation_similarity.py
+++ b/src/tdhook/latent/representation_similarity.py
@@ -1,5 +1,3 @@
 # CKA: Similarity of Neural Network Representations Revisited
 # Mutual k-Nearest Neighbor Alignment Metric: The Platonic Representation Hypothesis
 # Information Imbalance: A quantitative analysis of semantic information in deep representations of text and images
-
-# Two NN

--- a/src/tdhook/latent/representation_similarity.py
+++ b/src/tdhook/latent/representation_similarity.py
@@ -1,3 +1,5 @@
 # CKA: Similarity of Neural Network Representations Revisited
 # Mutual k-Nearest Neighbor Alignment Metric: The Platonic Representation Hypothesis
 # Information Imbalance: A quantitative analysis of semantic information in deep representations of text and images
+
+# Two NN

--- a/tests/latent/test_dimension_estimation.py
+++ b/tests/latent/test_dimension_estimation.py
@@ -77,15 +77,22 @@ class TestTwoNnDimensionEstimator:
         assert r2 > 0.9
 
     @pytest.mark.parametrize("return_xy", [True, False])
-    @pytest.mark.parametrize("shape", [(10, 5, 8), (10, 10, 4), (2, 3, 5, 8)], ids=["10x5x8", "10x10x4", "2x3x5x8"])
+    @pytest.mark.parametrize(
+        "shape",
+        [(1, 5, 8), (10, 5, 8), (10, 10, 4), (2, 3, 5, 8)],
+        ids=["1x5x8", "10x5x8", "10x10x4", "2x3x5x8"],
+    )
     def test_batch_size_preservation(self, run_estimator, shape, return_xy):
-        """Test that (..., N, D) preserves batch shape."""
+        """Test that (..., N, D) preserves batch shape, including size-1 batch axes."""
         data = torch.randn(*shape)
         batch_size = shape[:-2]
         result = run_estimator(data, batch_size=batch_size, return_xy=return_xy)
         assert "dimension" in result
         assert result["dimension"].shape == batch_size
         assert (result["dimension"] > 0).all()
+        if return_xy:
+            assert result["dimension_x"].shape[: len(batch_size)] == batch_size
+            assert result["dimension_y"].shape[: len(batch_size)] == batch_size
 
     def test_too_few_points_raises(self, run_estimator):
         """Test that fewer than 3 points raises."""

--- a/tests/latent/test_dimension_estimation.py
+++ b/tests/latent/test_dimension_estimation.py
@@ -4,6 +4,7 @@ Tests for intrinsic dimension estimation.
 
 import pytest
 import torch
+from sklearn.metrics import r2_score
 from tensordict import TensorDict
 
 from tdhook.latent.dimension_estimation import TwoNnDimensionEstimator
@@ -66,11 +67,14 @@ class TestTwoNnDimensionEstimator:
 
     def test_known_dimension_circle(self, run_estimator):
         """Test on 1D manifold (circle) embedded in 2D."""
-        theta = torch.randn(100) * torch.pi
+        theta = torch.rand(100) * 2 * torch.pi
         data = torch.stack([torch.cos(theta), torch.sin(theta)], dim=1)
-        result = run_estimator(data)
+        result = run_estimator(data, return_xy=True)
         d = result["dimension"].item()
+        x, y = result["dimension_x"].numpy(), result["dimension_y"].numpy()
+        r2 = r2_score(y, d * x)
         assert 0.5 < d < 1.5
+        assert r2 > 0.9
 
     @pytest.mark.parametrize("return_xy", [True, False])
     @pytest.mark.parametrize("shape", [(10, 5, 8), (10, 10, 4), (2, 3, 5, 8)], ids=["10x5x8", "10x10x4", "2x3x5x8"])

--- a/tests/latent/test_dimension_estimation.py
+++ b/tests/latent/test_dimension_estimation.py
@@ -1,0 +1,105 @@
+"""
+Tests for intrinsic dimension estimation.
+"""
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+from tdhook.latent.dimension_estimation import TwoNnDimensionEstimator
+
+
+class TestTwoNnDimensionEstimator:
+    """Test the TwoNnDimensionEstimator class."""
+
+    def test_default_keys(self):
+        """Test with default in_key and out_key."""
+        torch.manual_seed(42)
+        data = torch.randn(100, 10)
+        td = TensorDict({"data": data}, batch_size=[])
+        estimator = TwoNnDimensionEstimator()
+        result = estimator(td)
+        assert "dimension" in result
+        assert result["dimension"].ndim == 0
+        assert result["dimension"].dtype in (torch.float32, torch.float64)
+        assert result["dimension"].item() > 0
+
+    def test_custom_keys(self):
+        """Test with custom in_key and out_key."""
+        torch.manual_seed(42)
+        data = torch.randn(50, 8)
+        td = TensorDict({"linear2": data}, batch_size=[])
+        estimator = TwoNnDimensionEstimator(in_key="linear2", out_key="intrinsic_dim")
+        result = estimator(td)
+        assert "intrinsic_dim" in result
+        assert "linear2" in result
+        assert result["intrinsic_dim"].ndim == 0
+
+    def test_return_xy(self):
+        """Test that return_xy writes _x and _y keys."""
+        torch.manual_seed(42)
+        data = torch.randn(50, 5)
+        td = TensorDict({"data": data}, batch_size=[])
+        estimator = TwoNnDimensionEstimator(return_xy=True)
+        result = estimator(td)
+        assert "dimension" in result
+        assert "dimension_x" in result
+        assert "dimension_y" in result
+        x, y = result["dimension_x"], result["dimension_y"]
+        assert x.shape == y.shape
+        assert len(x) >= 3
+        d = result["dimension"].item()
+        # y ≈ d * x (through origin), so slope of regression is d
+        assert d > 0
+
+    def test_known_dimension_2d(self):
+        """Test on 2D manifold embedded in higher space."""
+        torch.manual_seed(42)
+        # Points on a 2D plane: only first 2 coords vary
+        data = torch.randn(100, 10)
+        data[:, 2:] = 0
+        td = TensorDict({"data": data}, batch_size=[])
+        estimator = TwoNnDimensionEstimator()
+        result = estimator(td)
+        d = result["dimension"].item()
+        # Should be close to 2 (with tolerance for finite sample)
+        assert 1.0 < d < 5.0
+
+    def test_known_dimension_3d(self):
+        """Test on 3D manifold embedded in higher space."""
+        torch.manual_seed(42)
+        data = torch.randn(150, 20)
+        data[:, 3:] = 0
+        td = TensorDict({"data": data}, batch_size=[])
+        estimator = TwoNnDimensionEstimator()
+        result = estimator(td)
+        d = result["dimension"].item()
+        assert 1.5 < d < 6.0
+
+    def test_flattened_input(self):
+        """Test that batched/sequential input is flattened correctly."""
+        torch.manual_seed(42)
+        # (batch, seq, features) -> flatten to (batch*seq, features)
+        data = torch.randn(10, 5, 8)  # 50 points
+        td = TensorDict({"data": data}, batch_size=[])
+        estimator = TwoNnDimensionEstimator()
+        result = estimator(td)
+        assert "dimension" in result
+        assert result["dimension"].ndim == 0
+
+    def test_too_few_points_raises(self):
+        """Test that fewer than 3 points raises."""
+        estimator = TwoNnDimensionEstimator()
+        td = TensorDict({"data": torch.randn(2, 5)}, batch_size=[])
+        with pytest.raises(ValueError, match="At least 3 points"):
+            estimator(td)
+
+    def test_determinism(self):
+        """Test that same input yields same output."""
+        torch.manual_seed(123)
+        data = torch.randn(80, 6)
+        td = TensorDict({"data": data}, batch_size=[])
+        estimator = TwoNnDimensionEstimator()
+        r1 = estimator(td.clone())["dimension"].item()
+        r2 = estimator(td.clone())["dimension"].item()
+        assert r1 == r2

--- a/tests/latent/test_dimension_estimation.py
+++ b/tests/latent/test_dimension_estimation.py
@@ -106,6 +106,7 @@ class TestTwoNnDimensionEstimator:
 
     def test_determinism(self, run_estimator):
         """Test that same input yields same output."""
+        torch.manual_seed(42)
         data = torch.randn(80, 6)
         r1 = run_estimator(data.clone())["dimension"]
         r2 = run_estimator(data.clone())["dimension"]

--- a/tests/latent/test_dimension_estimation.py
+++ b/tests/latent/test_dimension_estimation.py
@@ -106,3 +106,12 @@ class TestTwoNnDimensionEstimator:
         r1 = run_estimator(data.clone())["dimension"].item()
         r2 = run_estimator(data.clone())["dimension"].item()
         assert r1 == r2
+
+    def test_repr(self):
+        """Test __repr__ includes class name, in_keys, out_keys, and eps."""
+        est = TwoNnDimensionEstimator()
+        r = repr(est)
+        assert "TwoNnDimensionEstimator" in r
+        assert "in_keys=['data']" in r
+        assert "out_keys=['dimension']" in r
+        assert "eps=" in r

--- a/tests/latent/test_dimension_estimation.py
+++ b/tests/latent/test_dimension_estimation.py
@@ -106,11 +106,10 @@ class TestTwoNnDimensionEstimator:
 
     def test_determinism(self, run_estimator):
         """Test that same input yields same output."""
-        torch.manual_seed(123)
         data = torch.randn(80, 6)
-        r1 = run_estimator(data.clone())["dimension"].item()
-        r2 = run_estimator(data.clone())["dimension"].item()
-        assert r1 == r2
+        r1 = run_estimator(data.clone())["dimension"]
+        r2 = run_estimator(data.clone())["dimension"]
+        assert torch.allclose(r1, r2)
 
     def test_repr(self):
         """Test __repr__ includes class name, in_keys, out_keys, and eps."""

--- a/tests/latent/test_dimension_estimation.py
+++ b/tests/latent/test_dimension_estimation.py
@@ -99,6 +99,11 @@ class TestTwoNnDimensionEstimator:
         with pytest.raises(ValueError, match="At least 3 points"):
             run_estimator(torch.randn(2, 5))
 
+    def test_duplicate_points_raises(self, run_estimator):
+        """Test that all-duplicate points raises."""
+        with pytest.raises(ValueError, match="At least 3 valid points"):
+            run_estimator(torch.ones(5, 3))
+
     def test_determinism(self, run_estimator):
         """Test that same input yields same output."""
         torch.manual_seed(123)

--- a/tests/latent/test_dimension_estimation.py
+++ b/tests/latent/test_dimension_estimation.py
@@ -62,16 +62,15 @@ class TestTwoNnDimensionEstimator:
         data[:, 2:] = 0
         result = run_estimator(data)
         d = result["dimension"].item()
-        assert 1.0 < d < 3.0
+        assert 1.5 < d < 2.5
 
     def test_known_dimension_circle(self, run_estimator):
         """Test on 1D manifold (circle) embedded in 2D."""
-        theta = torch.linspace(0, 2 * torch.pi, 100)
+        theta = torch.randn(100) * torch.pi
         data = torch.stack([torch.cos(theta), torch.sin(theta)], dim=1)
-        data = data + 0.01 * torch.randn_like(data)  # small noise for numerical stability
         result = run_estimator(data)
         d = result["dimension"].item()
-        assert 0.5 < d < 6.0
+        assert 0.5 < d < 1.5
 
     @pytest.mark.parametrize("shape", [(10, 5, 8), (10, 10, 4), (2, 3, 5, 8)], ids=["10x5x8", "10x10x4", "2x3x5x8"])
     def test_batch_size_preservation(self, run_estimator, shape):


### PR DESCRIPTION
## What does this PR do?

Key insights about the PR.

## Linked Issues

- Address part of #34 

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/Xmaster6y/tdhook/blob/main/CONTRIBUTING.md) guide.
- [ ] I have added tests for my changes if needed.
- [ ] I have updated the documentation if needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds TwoNN intrinsic dimension estimation as a TensorDict module with batched support and optional x/y diagnostics. Fixes return_xy batch shape handling (multi-batch and size-1 axes) and seeds tests for stable determinism; addresses part of #34.

- **New Features**
  - TwoNnDimensionEstimator: reads (N, D) or (..., N, D); writes one scalar per dataset to out_key.
  - Optional return_xy: outputs log(mu) (x) and -log(1−F) (y); NaN-padded to keep batch shape.
  - eps to ignore near-duplicates; checks for minimum points and degeneracy.
  - Exported via tdhook.latent and latent.dimension_estimation; adds 2017 Sci Rep reference.
  - Tests for keys/diagnostics, known manifolds, batch-shape preservation, errors, seeded determinism, repr.

- **Bug Fixes**
  - Corrected multi-batch return_xy padding and reshaping to match leading batch dimensions.

<sup>Written for commit 46e1ae3bff9cb7767c13ed58dc6035cd7819c935. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

