### PR TITLE
[Feature] Local kNN dimension estimator

### DIFF
--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -227,6 +227,18 @@
   volume={abs/2403.01267},
 }
 
+@inproceedings{farahmand2007manifold,
+  title = {Manifold-adaptive dimension estimation},
+  author = {Farahmand, Amir massoud and Szepesv{\'a}ri, Csaba and Audibert, Jean-Yves},
+  booktitle = {Proceedings of the 24th International Conference on Machine Learning},
+  year = {2007},
+  pages = {265--272},
+  url = {https://doi.org/10.1145/1273496.1273530},
+  doi = {10.1145/1273496.1273530},
+  location = {Corvalis, Oregon, USA},
+  series = {ICML '07},
+}
+
 @article{facco_estimating_2017,
   title = {Estimating the intrinsic dimension of datasets by a minimal neighborhood information},
   volume = {7},

--- a/src/tdhook/latent/__init__.py
+++ b/src/tdhook/latent/__init__.py
@@ -4,7 +4,7 @@ Module for latent methods.
 
 from .activation_caching import ActivationCaching
 from .activation_patching import ActivationPatching
-from .dimension_estimation import TwoNnDimensionEstimator
+from .dimension_estimation import LocalKnnDimensionEstimator, TwoNnDimensionEstimator
 from .probing import Probing
 from .steering_vectors import SteeringVectors, ActivationAddition
 
@@ -12,6 +12,7 @@ __all__ = [
     "ActivationAddition",
     "ActivationCaching",
     "ActivationPatching",
+    "LocalKnnDimensionEstimator",
     "Probing",
     "SteeringVectors",
     "TwoNnDimensionEstimator",

--- a/src/tdhook/latent/dimension_estimation/__init__.py
+++ b/src/tdhook/latent/dimension_estimation/__init__.py
@@ -2,8 +2,10 @@
 Intrinsic dimension estimation methods.
 """
 
+from .local_knn import LocalKnnDimensionEstimator
 from .twonn import TwoNnDimensionEstimator
 
 __all__ = [
+    "LocalKnnDimensionEstimator",
     "TwoNnDimensionEstimator",
 ]

--- a/src/tdhook/latent/dimension_estimation/_utils.py
+++ b/src/tdhook/latent/dimension_estimation/_utils.py
@@ -1,0 +1,16 @@
+"""Shared utilities for intrinsic dimension estimation."""
+
+import torch
+
+
+def sorted_neighbor_distances(data: torch.Tensor, eps: float) -> torch.Tensor:
+    """Compute sorted distances to neighbors for each point.
+
+    Returns (N, N) where each row is sorted ascending. Self and distances <= eps are inf.
+    """
+    dist = torch.cdist(data, data, p=2)
+    dist = dist.clone()
+    dist.fill_diagonal_(float("inf"))
+    dist = torch.where(dist > eps, dist, float("inf"))
+    sorted_dist, _ = torch.sort(dist, dim=1)
+    return sorted_dist

--- a/src/tdhook/latent/dimension_estimation/local_knn.py
+++ b/src/tdhook/latent/dimension_estimation/local_knn.py
@@ -1,0 +1,76 @@
+"""Local intrinsic dimension estimation via k-nearest neighbors."""
+
+from textwrap import indent
+
+import torch
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModuleBase
+
+from ._utils import sorted_neighbor_distances
+
+
+class LocalKnnDimensionEstimator(TensorDictModuleBase):
+    """
+    Local intrinsic dimension estimation via k-NN distances.
+
+    For each point x, d(x) = ln(2) / ln(R2k/Rk), where Rk and R2k are distances
+    to the k-th and 2k-th nearest neighbors respectively.
+
+    Reads a data tensor from the input TensorDict. Expects (N, D) or (..., N, D).
+    Outputs per-point dimension estimates of shape (..., N).
+    """
+
+    def __init__(
+        self,
+        k: int,
+        in_key: str = "data",
+        out_key: str = "dimension",
+        eps: float = 1e-5,
+    ):
+        super().__init__()
+        if k < 1:
+            raise ValueError("k must be at least 1")
+        self.k = k
+        self.in_key = in_key
+        self.out_key = out_key
+        self.eps = eps
+        self.in_keys = [in_key]
+        self.out_keys = [out_key]
+
+    def forward(self, td: TensorDict) -> TensorDict:
+        data = td[self.in_key]
+        N = data.shape[-2]
+        if N < 2 * self.k + 1:
+            raise ValueError(f"At least 2k+1 points required for local KNN (k={self.k}), got {N}")
+        batch_shape = data.shape[:-2]
+        flat = data.reshape(-1, data.shape[-2], data.shape[-1])
+        dims = []
+        for i in range(flat.shape[0]):
+            d_i = _local_knn(flat[i], k=self.k, eps=self.eps)
+            dims.append(d_i)
+        td[self.out_key] = torch.stack(dims).reshape(*batch_shape, N)
+        return td
+
+    def __repr__(self):
+        fields = indent(
+            f"in_keys={self.in_keys},\nout_keys={self.out_keys},\nk={self.k},\neps={self.eps}",
+            4 * " ",
+        )
+        return f"{type(self).__name__}(\n{fields})"
+
+
+def _local_knn(data: torch.Tensor, k: int, eps: float) -> torch.Tensor:
+    """Compute per-point local dimension. data: (N, D). Returns (N,) dimension estimates."""
+    sorted_dist = sorted_neighbor_distances(data, eps)
+    rk = sorted_dist[:, k - 1]
+    r2k = sorted_dist[:, 2 * k - 1]
+
+    valid = torch.isfinite(rk) & torch.isfinite(r2k) & (r2k > rk)
+    ratio = r2k / rk
+    log_ratio = torch.log(ratio)
+
+    d = torch.full_like(rk, float("nan"))
+    d[valid] = torch.log(torch.tensor(2.0, device=data.device, dtype=data.dtype)) / log_ratio[valid]
+    d[~valid] = float("nan")
+
+    return d.float()

--- a/src/tdhook/latent/dimension_estimation/local_knn.py
+++ b/src/tdhook/latent/dimension_estimation/local_knn.py
@@ -1,5 +1,3 @@
-"""Local intrinsic dimension estimation via k-nearest neighbors."""
-
 from textwrap import indent
 from typing import Literal, Union
 
@@ -19,7 +17,7 @@ def _resolve_k(k: Union[int, Literal["auto"]], n: int) -> int:
 
 class LocalKnnDimensionEstimator(TensorDictModuleBase):
     """
-    Local intrinsic dimension estimation via k-NN distances.
+    Local intrinsic dimension estimation via k-NN distances :cite:`farahmand2007manifold`.
 
     For each point x, d(x) = ln(2) / ln(R2k/Rk), where Rk and R2k are distances
     to the k-th and 2k-th nearest neighbors respectively.

--- a/src/tdhook/latent/dimension_estimation/twonn.py
+++ b/src/tdhook/latent/dimension_estimation/twonn.py
@@ -4,6 +4,8 @@ import torch
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModuleBase
 
+from ._utils import sorted_neighbor_distances
+
 
 class TwoNnDimensionEstimator(TensorDictModuleBase):
     """
@@ -69,11 +71,7 @@ def _twonn(data: torch.Tensor, eps: float) -> tuple[torch.Tensor, torch.Tensor, 
 
     Distances <= eps are treated as duplicates (excluded from nearest-neighbor selection).
     """
-    dist = torch.cdist(data, data, p=2)
-    dist = dist.clone()
-    dist.fill_diagonal_(float("inf"))
-    dist = torch.where(dist > eps, dist, float("inf"))
-    sorted_dist, _ = torch.sort(dist, dim=1)
+    sorted_dist = sorted_neighbor_distances(data, eps)
     r1 = sorted_dist[:, 0]
     r2 = sorted_dist[:, 1]
 


### PR DESCRIPTION
## What does this PR do?

Key insights about the PR.

## Linked Issues

- Closes #?
- #?

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/Xmaster6y/tdhook/blob/main/CONTRIBUTING.md) guide.
- [ ] I have added tests for my changes if needed.
- [ ] I have updated the documentation if needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a per-point local intrinsic dimension estimator using k-NN distances, plus a shared neighbor-distance utility now used by TwoNn for consistent filtering and duplicate handling. Docs now cite Farahmand et al. (2007).

- **New Features**
  - LocalKnnDimensionEstimator(k | "auto") computes d(x) = ln(2) / ln(R2k/Rk); validates k, requires N ≥ 2k+1, and ignores self/≤eps neighbors.
  - Supports (N, D) and (..., N, D); outputs (..., N). Configurable in_key/out_key and eps. Exported in tdhook.latent and tdhook.latent.dimension_estimation; tests cover batch/custom keys, determinism, known manifolds, auto-k, and error cases.

- **Refactors**
  - Added sorted_neighbor_distances in _utils and switched TwoNnDimensionEstimator to use it to reduce duplication and unify neighbor filtering.
  - Added ICML '07 citation (Farahmand–Szepesvári–Audibert) to references.

<sup>Written for commit 42463fb6135d7d3c5ddcf86d6cfd4b2f94e59b16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

