### PR TITLE
[Chore] Notebook fixes

### DIFF
--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -1,9 +1,0 @@
-About `tdhook`
-=============
-
-Coming soon...
-
-References
-----------
-
-.. bibliography::

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -96,7 +96,7 @@ html_theme_options = {
         "version_match": version_match,
     },
 }
-html_sidebars = {"about": [], "start": []}
+html_sidebars = {"start": []}
 
 html_context = {"default_mode": "auto"}
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,7 @@
     methods
     tutorials
     api/index
-    About <about>
+    references
 
 .. grid:: 1 1 2 2
     :class-container: hero

--- a/docs/source/notebooks/tutorials/chess-dimension-estimation.ipynb
+++ b/docs/source/notebooks/tutorials/chess-dimension-estimation.ipynb
@@ -9,7 +9,7 @@
         "\n",
         "This tutorial estimates intrinsic dimension from chess-network activations channel by channel, then compares trends across backbone layers and head-adjacent features.\n",
         "\n",
-        "The workflow builds on LCZeroLens usage patterns and references LCZeroLens :cite:`Yoann_Poupart_LCZeroLens`."
+        "The workflow builds on LCZeroLens usage patterns and references <cite data-cite=\"Yoann_Poupart_LCZeroLens\">LCZeroLens</cite>."
       ]
     },
     {
@@ -1287,6 +1287,16 @@
         "- Per-channel intrinsic dimension is sensitive to sample size and to highly redundant activations.\n",
         "- Per-square board estimates use all `N` samples at each fixed square `(h, w)` with channel features as coordinates.\n",
         "- Head-module names can vary by model export; this notebook targets policy/value first-conv activations."
+      ]
+    },
+    {
+      "cell_type": "raw",
+      "id": "35ec19b7",
+      "metadata": {
+        "raw_mimetype": "text/restructuredtext"
+      },
+      "source": [
+        ".. bibliography::"
       ]
     }
   ],

--- a/docs/source/notebooks/tutorials/chess-dimension-estimation.ipynb
+++ b/docs/source/notebooks/tutorials/chess-dimension-estimation.ipynb
@@ -1288,16 +1288,6 @@
         "- Per-square board estimates use all `N` samples at each fixed square `(h, w)` with channel features as coordinates.\n",
         "- Head-module names can vary by model export; this notebook targets policy/value first-conv activations."
       ]
-    },
-    {
-      "cell_type": "raw",
-      "id": "35ec19b7",
-      "metadata": {
-        "raw_mimetype": "text/restructuredtext"
-      },
-      "source": [
-        ".. bibliography::"
-      ]
     }
   ],
   "metadata": {

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -1,0 +1,4 @@
+References
+==========
+
+.. bibliography::

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -88,23 +88,6 @@ Tutorials
             </div>
          </div>
 
-   .. grid-item-card::
-      :link: notebooks/tutorials/chess-cross-model-probing.ipynb
-      :class-card: surface
-      :class-body: surface
-
-      .. raw:: html
-
-         <div class="d-flex align-items-center">
-            <div class="d-flex justify-content-center" style="min-width: 50px; margin-right: 20px; height: 100%;">
-               <i class="fa-solid fa-chess fa-2x"></i>
-            </div>
-            <div>
-               <h5 class="card-title">Chess Cross-Model Probing</h5>
-               <p class="card-text">Linear probing on Maia models: can one model's latents predict another's moves? Compare absolute best vs best legal.</p>
-            </div>
-         </div>
-
 .. toctree::
    :hidden:
    :maxdepth: 2
@@ -113,4 +96,3 @@ Tutorials
    notebooks/tutorials/chess-value-saliency.ipynb
    notebooks/tutorials/concept-attribution.ipynb
    notebooks/tutorials/chess-dimension-estimation.ipynb
-   notebooks/tutorials/chess-cross-model-probing.ipynb

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -88,6 +88,23 @@ Tutorials
             </div>
          </div>
 
+   .. grid-item-card::
+      :link: notebooks/tutorials/chess-cross-model-probing.ipynb
+      :class-card: surface
+      :class-body: surface
+
+      .. raw:: html
+
+         <div class="d-flex align-items-center">
+            <div class="d-flex justify-content-center" style="min-width: 50px; margin-right: 20px; height: 100%;">
+               <i class="fa-solid fa-chess fa-2x"></i>
+            </div>
+            <div>
+               <h5 class="card-title">Chess Cross-Model Probing</h5>
+               <p class="card-text">Linear probing on Maia models: can one model's latents predict another's moves? Compare absolute best vs best legal.</p>
+            </div>
+         </div>
+
 .. toctree::
    :hidden:
    :maxdepth: 2
@@ -96,3 +113,4 @@ Tutorials
    notebooks/tutorials/chess-value-saliency.ipynb
    notebooks/tutorials/concept-attribution.ipynb
    notebooks/tutorials/chess-dimension-estimation.ipynb
+   notebooks/tutorials/chess-cross-model-probing.ipynb


### PR DESCRIPTION
## What does this PR do?

Key insights about the PR.

## Linked Issues

- Closes #?
- #?

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/Xmaster6y/tdhook/blob/main/CONTRIBUTING.md) guide.
- [ ] I have added tests for my changes if needed.
- [ ] I have updated the documentation if needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes citation rendering in the chess and concept attribution notebooks by switching to <cite data-cite> and moves the bibliography to a new References page. Cleans docs navigation by removing the About page and dead references and updating the sidebar/index; no analysis logic changes.

<sup>Written for commit 0720cc2b7f4543e955708cf808ab6be1d21c10be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

