### PR TITLE
[Chore] `llms.txt` support

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,6 +21,7 @@ extensions = [
     "nbsphinx",  # Jupyter notebook support
     "sphinxcontrib.bibtex",  # BibTeX citation support
     "autoapi.extension",
+    "sphinx_llm.txt",
 ]
 
 # BibTeX configuration

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,8 +20,8 @@ extensions = [
     "sphinx_design",  # Boostrap design components
     "nbsphinx",  # Jupyter notebook support
     "sphinxcontrib.bibtex",  # BibTeX citation support
-    "autoapi.extension",
-    "sphinx_llm.txt",
+    "autoapi.extension",  # Auto documentation from code
+    "sphinx_llm.txt",  # LLM support
 ]
 
 # BibTeX configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ docs = [
     "sphinx-charts>=0.2.1",
     "sphinx-copybutton>=0.5.2",
     "sphinx-design>=0.6.1",
+    "sphinx-llm>=0.3.0",
     "sphinxcontrib-bibtex>=2.6.5",
 ]
 scripts = [

--- a/uv.lock
+++ b/uv.lock
@@ -4011,6 +4011,33 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinx-llm"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+    { name = "sphinx-markdown-builder" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/69/128ba4687f19974c3a87816482a0fad49b69698bb980c467dd18919d0829/sphinx_llm-0.3.0.tar.gz", hash = "sha256:a994676ee914a5b0415d6607aec9578eb004fc61aaa2b13d27dc8a6729c97791", size = 271045, upload-time = "2026-02-06T09:28:53.047Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/60/153e9130dd8bf49fb5b7a5f89dda851de5aa87eea45e00f93c30d2b52a45/sphinx_llm-0.3.0-py3-none-any.whl", hash = "sha256:4e89d7978d4bc8f755fe89e24e2c0e3a90e60fa6b8740119c9b4a9fd274dff9e", size = 22335, upload-time = "2026-02-06T09:28:51.419Z" },
+]
+
+[[package]]
+name = "sphinx-markdown-builder"
+version = "0.6.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "sphinx" },
+    { name = "tabulate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/58/0b7b9a7d071140b3705885d51932e8b62f520388c2772e4952189971727b/sphinx_markdown_builder-0.6.10.tar.gz", hash = "sha256:cd5acf88d52ea0146a712fd557404f10326dff3428a78ba928e59b1727fd4a86", size = 22688, upload-time = "2026-03-11T10:56:57.639Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/8f/9fecf3d081d5cd49eff83a17b9fef50ed741e6223ab3bb906de4ab0068f9/sphinx_markdown_builder-0.6.10-py3-none-any.whl", hash = "sha256:16d86738b9ac69fcbc86e373c31c6402c30af1fa8d98d0f62cc5f38bfe5fc26e", size = 16700, upload-time = "2026-03-11T10:56:56.135Z" },
+]
+
+[[package]]
 name = "sphinxcontrib-applehelp"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4106,6 +4133,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
 name = "tdhook"
 version = "0.1.3.dev0"
 source = { editable = "." }
@@ -4136,6 +4172,7 @@ docs = [
     { name = "sphinx-charts" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
+    { name = "sphinx-llm" },
     { name = "sphinxcontrib-bibtex" },
 ]
 notebooks = [
@@ -4188,6 +4225,7 @@ docs = [
     { name = "sphinx-charts", specifier = ">=0.2.1" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-design", specifier = ">=0.6.1" },
+    { name = "sphinx-llm", specifier = ">=0.3.0" },
     { name = "sphinxcontrib-bibtex", specifier = ">=2.6.5" },
 ]
 notebooks = [


### PR DESCRIPTION
## What does this PR do?

Key insights about the PR.

## Linked Issues

- Closes #?
- #?

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/Xmaster6y/tdhook/blob/main/CONTRIBUTING.md) guide.
- [ ] I have added tests for my changes if needed.
- [ ] I have updated the documentation if needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `llm.txt` support to the docs by installing `sphinx-llm` and enabling the `sphinx_llm.txt` extension in Sphinx. This builds a single, LLM‑friendly text file from our documentation.

- **Dependencies**
  - Added `sphinx-llm@>=0.3.0` (docs extra); pulls in `sphinx-markdown-builder@0.6.10` and `tabulate@0.10.0`.

<sup>Written for commit e057ce81494f3fbbde99ede9fd756f3072b85ca8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

