### PR TITLE
Information imbalance for representation similarity

### DIFF
--- a/docs/source/notebooks/methods/representation-similarity.ipynb
+++ b/docs/source/notebooks/methods/representation-similarity.ipynb
@@ -23,7 +23,9 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 1,
       "metadata": {},
+      "outputs": [],
       "source": [
         "import importlib.util\n",
         "\n",
@@ -33,13 +35,13 @@
         "    MODE = \"colab-dev\" if DEV else \"colab\"\n",
         "else:\n",
         "    MODE = \"local\""
-      ],
-      "execution_count": 1,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 2,
       "metadata": {},
+      "outputs": [],
       "source": [
         "if MODE == \"colab\":\n",
         "    %pip install -q tdhook\n",
@@ -47,9 +49,7 @@
         "    !rm -rf tdhook\n",
         "    !git clone https://github.com/Xmaster6y/tdhook -b main\n",
         "    %pip install -q ./tdhook"
-      ],
-      "execution_count": 2,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -60,15 +60,15 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 3,
       "metadata": {},
+      "outputs": [],
       "source": [
         "import torch\n",
         "from tensordict import TensorDict\n",
         "\n",
         "from tdhook.latent.representation_similarity import CkaEstimator, InformationImbalanceEstimator"
-      ],
-      "execution_count": 3,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -85,7 +85,9 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 4,
       "metadata": {},
+      "outputs": [],
       "source": [
         "torch.manual_seed(0)\n",
         "\n",
@@ -104,28 +106,28 @@
         "def run_cka(x, y):\n",
         "    td = TensorDict({\"data_a\": x, \"data_b\": y}, batch_size=[])\n",
         "    return estimator(td.clone())[\"cka\"].item()"
-      ],
-      "execution_count": 4,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "scores = {name: run_cka(a, b) for name, (a, b) in examples.items()}\n",
-        "# Display CKA scores for each synthetic pair.\n",
-        "scores"
-      ],
       "execution_count": 5,
+      "metadata": {},
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "{'same': 1.0, 'rotated': 1.0, 'random': 0.10095701366662979}"
             ]
-          }
+          },
+          "execution_count": 5,
+          "metadata": {},
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "scores = {name: run_cka(a, b) for name, (a, b) in examples.items()}\n",
+        "# Display CKA scores for each synthetic pair.\n",
+        "scores"
       ]
     },
     {
@@ -139,24 +141,26 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 6,
       "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "tensor([0.9979, 0.9978, 0.9976])"
+            ]
+          },
+          "execution_count": 6,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "batched_x = torch.randn(3, 128, 16)\n",
         "batched_y = batched_x + 0.05 * torch.randn(3, 128, 16)\n",
         "\n",
         "td = TensorDict({\"data_a\": batched_x, \"data_b\": batched_y}, batch_size=[3])\n",
         "CkaEstimator()(td.clone())[\"cka\"]"
-      ],
-      "execution_count": 6,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "tensor([0.9979, 0.9978, 0.9976])"
-            ]
-          }
-        }
       ]
     },
     {
@@ -190,7 +194,28 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 7,
       "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "TensorDict(\n",
+              "    fields={\n",
+              "        data_a: Tensor(shape=torch.Size([128, 1]), device=cpu, dtype=torch.float32, is_shared=False),\n",
+              "        data_b: Tensor(shape=torch.Size([128, 1]), device=cpu, dtype=torch.float32, is_shared=False),\n",
+              "        information_imbalance_a_to_b: Tensor(shape=torch.Size([]), device=cpu, dtype=torch.float32, is_shared=False),\n",
+              "        information_imbalance_b_to_a: Tensor(shape=torch.Size([]), device=cpu, dtype=torch.float32, is_shared=False)},\n",
+              "    batch_size=torch.Size([]),\n",
+              "    device=None,\n",
+              "    is_shared=False)"
+            ]
+          },
+          "execution_count": 7,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "t = torch.linspace(-1.0, 1.0, 128)\n",
         "data_a = t.unsqueeze(-1)\n",
@@ -198,9 +223,7 @@
         "\n",
         "td = TensorDict({\"data_a\": data_a, \"data_b\": data_b}, batch_size=[])\n",
         "InformationImbalanceEstimator()(td.clone())"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     }
   ],
   "metadata": {

--- a/docs/source/notebooks/methods/representation-similarity.ipynb
+++ b/docs/source/notebooks/methods/representation-similarity.ipynb
@@ -1,197 +1,227 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Representation Similarity\n",
-    "\n",
-    "This notebook introduces representation similarity methods in `tdhook`.\n",
-    "\n",
-    "It currently starts with centered kernel alignment (CKA) through `tdhook.latent.representation_similarity.CkaEstimator`. More similarity methods can be added here later as the module grows."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Setup"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import importlib.util\n",
-    "\n",
-    "DEV = True\n",
-    "\n",
-    "if importlib.util.find_spec(\"google.colab\") is not None:\n",
-    "    MODE = \"colab-dev\" if DEV else \"colab\"\n",
-    "else:\n",
-    "    MODE = \"local\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if MODE == \"colab\":\n",
-    "    %pip install -q tdhook\n",
-    "elif MODE == \"colab-dev\":\n",
-    "    !rm -rf tdhook\n",
-    "    !git clone https://github.com/Xmaster6y/tdhook -b main\n",
-    "    %pip install -q ./tdhook"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Imports"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import torch\n",
-    "from tensordict import TensorDict\n",
-    "\n",
-    "from tdhook.latent.representation_similarity import CkaEstimator"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Synthetic Example\n",
-    "\n",
-    "We build a few pairs of representations with known relationships:\n",
-    "\n",
-    "- `same`: identical representations, so CKA should be close to `1`\n",
-    "- `rotated`: an orthogonal transform of the same representation, which linear CKA should also score near `1`\n",
-    "- `random`: an unrelated representation, which should typically score much lower"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "torch.manual_seed(0)\n",
-    "\n",
-    "x = torch.randn(256, 32)\n",
-    "q, _ = torch.linalg.qr(torch.randn(32, 32))\n",
-    "\n",
-    "examples = {\n",
-    "    \"same\": (x, x.clone()),\n",
-    "    \"rotated\": (x, x @ q),\n",
-    "    \"random\": (x, torch.randn(256, 24)),\n",
-    "}\n",
-    "\n",
-    "estimator = CkaEstimator(kernel=\"linear\")\n",
-    "\n",
-    "\n",
-    "def run_cka(x, y):\n",
-    "    td = TensorDict({\"data_a\": x, \"data_b\": y}, batch_size=[])\n",
-    "    return estimator(td.clone())[\"cka\"].item()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
+  "cells": [
     {
-     "data": {
-      "text/plain": [
-       "{'same': 1.0, 'rotated': 1.0, 'random': 0.10095701366662979}"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Representation Similarity\n",
+        "\n",
+        "This notebook introduces representation similarity methods in `tdhook`.\n",
+        "\n",
+        "It currently covers:\n",
+        "\n",
+        "- centered kernel alignment (CKA) through `tdhook.latent.representation_similarity.CkaEstimator`\n",
+        "- Information Imbalance through `tdhook.latent.representation_similarity.InformationImbalanceEstimator`"
       ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "scores = {name: run_cka(a, b) for name, (a, b) in examples.items()}\n",
-    "scores"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Batched Inputs\n",
-    "\n",
-    "Like the dimension-estimation modules, `CkaEstimator` accepts either `(N, D)` or batched `(..., N, D)` inputs and returns one scalar score per batch item."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "data": {
-      "text/plain": [
-       "tensor([0.9979, 0.9978, 0.9976])"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Setup"
       ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import importlib.util\n",
+        "\n",
+        "DEV = True\n",
+        "\n",
+        "if importlib.util.find_spec(\"google.colab\") is not None:\n",
+        "    MODE = \"colab-dev\" if DEV else \"colab\"\n",
+        "else:\n",
+        "    MODE = \"local\""
+      ],
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "if MODE == \"colab\":\n",
+        "    %pip install -q tdhook\n",
+        "elif MODE == \"colab-dev\":\n",
+        "    !rm -rf tdhook\n",
+        "    !git clone https://github.com/Xmaster6y/tdhook -b main\n",
+        "    %pip install -q ./tdhook"
+      ],
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Imports"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import torch\n",
+        "from tensordict import TensorDict\n",
+        "\n",
+        "from tdhook.latent.representation_similarity import CkaEstimator, InformationImbalanceEstimator"
+      ],
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Synthetic Example\n",
+        "\n",
+        "We build a few pairs of representations with known relationships:\n",
+        "\n",
+        "- `same`: identical representations, so CKA should be close to `1`\n",
+        "- `rotated`: an orthogonal transform of the same representation, which linear CKA should also score near `1`\n",
+        "- `random`: an unrelated representation, which should typically score much lower"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "torch.manual_seed(0)\n",
+        "\n",
+        "x = torch.randn(256, 32)\n",
+        "q, _ = torch.linalg.qr(torch.randn(32, 32))\n",
+        "\n",
+        "examples = {\n",
+        "    \"same\": (x, x.clone()),\n",
+        "    \"rotated\": (x, x @ q),\n",
+        "    \"random\": (x, torch.randn(256, 24)),\n",
+        "}\n",
+        "\n",
+        "estimator = CkaEstimator(kernel=\"linear\")\n",
+        "\n",
+        "\n",
+        "def run_cka(x, y):\n",
+        "    td = TensorDict({\"data_a\": x, \"data_b\": y}, batch_size=[])\n",
+        "    return estimator(td.clone())[\"cka\"].item()"
+      ],
+      "execution_count": 4,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "scores = {name: run_cka(a, b) for name, (a, b) in examples.items()}\n",
+        "# Display CKA scores for each synthetic pair.\n",
+        "scores"
+      ],
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "{'same': 1.0, 'rotated': 1.0, 'random': 0.10095701366662979}"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Batched Inputs\n",
+        "\n",
+        "Like the dimension-estimation modules, `CkaEstimator` accepts either `(N, D)` or batched `(..., N, D)` inputs and returns one scalar score per batch item."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "batched_x = torch.randn(3, 128, 16)\n",
+        "batched_y = batched_x + 0.05 * torch.randn(3, 128, 16)\n",
+        "\n",
+        "td = TensorDict({\"data_a\": batched_x, \"data_b\": batched_y}, batch_size=[3])\n",
+        "CkaEstimator()(td.clone())[\"cka\"]"
+      ],
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "tensor([0.9979, 0.9978, 0.9976])"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## API Notes\n",
+        "\n",
+        "- The estimator is named `CkaEstimator` and already exposes a `kernel` argument.\n",
+        "- At the moment only `kernel=\"linear\"` is implemented.\n",
+        "- Degenerate inputs with zero variance return `nan` instead of raising.\n",
+        "\n",
+        "Future methods can extend this notebook with additional sections, comparisons, and visualizations."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Information Imbalance\n",
+        "\n",
+        "`InformationImbalanceEstimator` compares how much neighborhood information is preserved from one representation space to another using distance ranks.\n",
+        "\n",
+        "It returns two directional values:\n",
+        "\n",
+        "- `information_imbalance_a_to_b`\n",
+        "- `information_imbalance_b_to_a`\n",
+        "\n",
+        "Lower values indicate that the source representation is more informative about the target space."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "t = torch.linspace(-1.0, 1.0, 128)\n",
+        "data_a = t.unsqueeze(-1)\n",
+        "data_b = (4 * t).round().unsqueeze(-1) / 4.0\n",
+        "\n",
+        "td = TensorDict({\"data_a\": data_a, \"data_b\": data_b}, batch_size=[])\n",
+        "InformationImbalanceEstimator()(td.clone())"
+      ],
+      "execution_count": null,
+      "outputs": []
     }
-   ],
-   "source": [
-    "batched_x = torch.randn(3, 128, 16)\n",
-    "batched_y = batched_x + 0.05 * torch.randn(3, 128, 16)\n",
-    "\n",
-    "td = TensorDict({\"data_a\": batched_x, \"data_b\": batched_y}, batch_size=[3])\n",
-    "CkaEstimator()(td.clone())[\"cka\"]"
-   ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.10"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## API Notes\n",
-    "\n",
-    "- The estimator is named `CkaEstimator` and already exposes a `kernel` argument.\n",
-    "- At the moment only `kernel=\"linear\"` is implemented.\n",
-    "- Degenerate inputs with zero variance return `nan` instead of raising.\n",
-    "\n",
-    "Future methods can extend this notebook with additional sections, comparisons, and visualizations."
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": ".venv",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.10"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 4
 }

--- a/src/tdhook/latent/__init__.py
+++ b/src/tdhook/latent/__init__.py
@@ -15,7 +15,7 @@ from .probing import (
     Probe,
     ProbeManager,
 )
-from .representation_similarity import CkaEstimator
+from .representation_similarity import CkaEstimator, InformationImbalanceEstimator
 from .steering_vectors import SteeringVectors, ActivationAddition
 
 __all__ = [
@@ -25,6 +25,7 @@ __all__ = [
     "BilinearProbe",
     "BilinearProbeManager",
     "CkaEstimator",
+    "InformationImbalanceEstimator",
     "LinearEstimator",
     "LowRankBilinearEstimator",
     "LocalKnnDimensionEstimator",

--- a/src/tdhook/latent/representation_similarity/__init__.py
+++ b/src/tdhook/latent/representation_similarity/__init__.py
@@ -3,5 +3,6 @@ Representation similarity methods.
 """
 
 from .cka import CkaEstimator
+from .information_imbalance import InformationImbalanceEstimator
 
-__all__ = ["CkaEstimator"]
+__all__ = ["CkaEstimator", "InformationImbalanceEstimator"]

--- a/src/tdhook/latent/representation_similarity/information_imbalance.py
+++ b/src/tdhook/latent/representation_similarity/information_imbalance.py
@@ -1,0 +1,143 @@
+from textwrap import indent
+
+import torch
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModuleBase
+
+
+class InformationImbalanceEstimator(TensorDictModuleBase):
+    """
+    Information Imbalance between two representations.
+
+    Reads two data tensors from the input TensorDict. Expects `(N, D)` or
+    `(..., N, D)` for both tensors, with shared batch shape and sample count.
+    Outputs both directional imbalances per batch item: A->B and B->A.
+
+    This implementation uses the nearest-neighbor definition:
+    for each point i, select j such that r^A_ij = 1 and average r^B_ij with
+    normalization 2 / N, yielding values close to 0 for strong
+    neighborhood predictability and close to 1 for uninformative mappings.
+    """
+
+    def __init__(
+        self,
+        in_key_a: str = "data_a",
+        in_key_b: str = "data_b",
+        out_key_a_to_b: str = "information_imbalance_a_to_b",
+        out_key_b_to_a: str = "information_imbalance_b_to_a",
+        p: float = 2.0,
+    ):
+        super().__init__()
+
+        self.in_key_a = in_key_a
+        self.in_key_b = in_key_b
+        self.out_key_a_to_b = out_key_a_to_b
+        self.out_key_b_to_a = out_key_b_to_a
+        self.p = p
+        self.in_keys = [in_key_a, in_key_b]
+        self.out_keys = [out_key_a_to_b, out_key_b_to_a]
+
+    def forward(self, td: TensorDict) -> TensorDict:
+        x = td[self.in_key_a]
+        y = td[self.in_key_b]
+        _validate_inputs(x, y)
+
+        batch_shape = x.shape[:-2]
+        n = x.shape[-2]
+        flat_x = x.reshape(-1, n, x.shape[-1])
+        flat_y = y.reshape(-1, n, y.shape[-1])
+        if flat_x.shape[0] == 0:
+            empty = torch.empty(batch_shape, dtype=torch.float32, device=x.device)
+            td[self.out_key_a_to_b] = empty
+            td[self.out_key_b_to_a] = empty.clone()
+            return td
+
+        values_a_to_b = []
+        values_b_to_a = []
+        for i in range(flat_x.shape[0]):
+            a_to_b, b_to_a = _information_imbalance(flat_x[i], flat_y[i], p=self.p)
+            values_a_to_b.append(a_to_b)
+            values_b_to_a.append(b_to_a)
+
+        td[self.out_key_a_to_b] = torch.stack(values_a_to_b).reshape(batch_shape)
+        td[self.out_key_b_to_a] = torch.stack(values_b_to_a).reshape(batch_shape)
+        return td
+
+    def __repr__(self):
+        fields = indent(
+            (f"in_keys={self.in_keys},\nout_keys={self.out_keys},\np={self.p}"),
+            4 * " ",
+        )
+        return f"{type(self).__name__}(\n{fields})"
+
+
+def _validate_inputs(x: torch.Tensor, y: torch.Tensor) -> None:
+    if x.ndim < 2 or y.ndim < 2:
+        raise ValueError("Information Imbalance expects tensors with shape (N, D) or (..., N, D)")
+    if x.shape[:-2] != y.shape[:-2]:
+        raise ValueError(f"Expected matching batch shapes, got {x.shape[:-2]} and {y.shape[:-2]}")
+    if x.shape[-2] != y.shape[-2]:
+        raise ValueError(f"Expected matching sample counts, got {x.shape[-2]} and {y.shape[-2]}")
+    if x.device != y.device:
+        raise ValueError(f"Expected both tensors on the same device, got {x.device} and {y.device}")
+
+    n = x.shape[-2]
+    if n < 2:
+        raise ValueError(f"Expected at least 2 samples, got {n}")
+
+
+def _compute_ranks_from_dist(dist: torch.Tensor) -> torch.Tensor:
+    """
+    Convert pairwise distances (N, N) to rank matrix (N, N).
+
+    Convention: diagonal entries (self) have rank 0 and non-diagonal entries are
+    ranked from 1 to N-1 according to ascending distance for each row.
+    """
+    n = dist.shape[0]
+    working = dist.clone()
+    working.fill_diagonal_(float("-inf"))
+    order = torch.argsort(working, dim=1)
+
+    rank_values = torch.arange(n, device=dist.device, dtype=torch.int64).expand(n, -1)
+    ranks = torch.empty_like(order, dtype=torch.int64)
+    ranks.scatter_(1, order, rank_values)
+    return ranks
+
+
+def _as_distance_input_dtype(x: torch.Tensor, y: torch.Tensor) -> torch.dtype:
+    dtype = torch.promote_types(x.dtype, y.dtype)
+    if not torch.empty((), dtype=dtype).is_floating_point():
+        return torch.float32
+    return dtype
+
+
+def _directional_imbalance(
+    source_ranks: torch.Tensor,
+    target_ranks: torch.Tensor,
+) -> torch.Tensor:
+    n = source_ranks.shape[0]
+    source_mask = source_ranks == 1
+    selected_target_ranks = target_ranks[source_mask].to(dtype=torch.float32)
+    avg_rank = selected_target_ranks.mean()
+    return (2.0 / n) * avg_rank
+
+
+def _information_imbalance(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    *,
+    p: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    dtype = _as_distance_input_dtype(x, y)
+    x = x.to(dtype=dtype)
+    y = y.to(dtype=dtype)
+
+    dist_a = torch.cdist(x, x, p=p)
+    dist_b = torch.cdist(y, y, p=p)
+
+    ranks_a = _compute_ranks_from_dist(dist_a)
+    ranks_b = _compute_ranks_from_dist(dist_b)
+
+    a_to_b = _directional_imbalance(ranks_a, ranks_b)
+    b_to_a = _directional_imbalance(ranks_b, ranks_a)
+    return a_to_b, b_to_a

--- a/tests/latent/test_representation_similarity.py
+++ b/tests/latent/test_representation_similarity.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 from tensordict import TensorDict
 
-from tdhook.latent.representation_similarity import CkaEstimator
+from tdhook.latent.representation_similarity import CkaEstimator, InformationImbalanceEstimator
 
 
 def make_td(x, y, in_key_a="data_a", in_key_b="data_b", batch_size=None):
@@ -169,3 +169,163 @@ class TestCkaEstimator:
     def test_unknown_kernel_raises(self):
         with pytest.raises(NotImplementedError, match="Only 'linear' is implemented"):
             CkaEstimator(kernel="rbf")
+
+
+class TestInformationImbalanceEstimator:
+    @pytest.fixture
+    def run_estimator(self):
+        torch.manual_seed(42)
+
+        def _run(x, y, in_key_a="data_a", in_key_b="data_b", batch_size=None, **estimator_kwargs):
+            td = make_td(x, y, in_key_a=in_key_a, in_key_b=in_key_b, batch_size=batch_size)
+            return InformationImbalanceEstimator(
+                in_key_a=in_key_a,
+                in_key_b=in_key_b,
+                **estimator_kwargs,
+            )(td)
+
+        return _run
+
+    def test_default_keys(self, run_estimator):
+        x, y = make_random_pair()
+        result = run_estimator(x, y)
+
+        assert "information_imbalance_a_to_b" in result
+        assert "information_imbalance_b_to_a" in result
+        assert result["information_imbalance_a_to_b"].ndim == 0
+        assert result["information_imbalance_b_to_a"].ndim == 0
+
+    def test_custom_keys(self, run_estimator):
+        x = torch.randn(64, 10)
+        y = torch.randn(64, 8)
+        result = run_estimator(
+            x,
+            y,
+            in_key_a="linear1",
+            in_key_b="linear2",
+            out_key_a_to_b="imb12",
+            out_key_b_to_a="imb21",
+        )
+
+        assert "linear1" in result
+        assert "linear2" in result
+        assert "imb12" in result
+        assert "imb21" in result
+        assert result["imb12"].ndim == 0
+        assert result["imb21"].ndim == 0
+
+    def test_outputs_are_finite_for_random_data(self, run_estimator):
+        x = torch.randn(128, 16)
+        y = torch.randn(128, 12)
+        result = run_estimator(x, y)
+
+        assert torch.isfinite(result["information_imbalance_a_to_b"])
+        assert torch.isfinite(result["information_imbalance_b_to_a"])
+
+    def test_directional_asymmetry(self, run_estimator):
+        n = 120
+        t = torch.linspace(-1.0, 1.0, n)
+        x = t.unsqueeze(-1)
+        y = (4 * t).round().unsqueeze(-1) / 4.0
+
+        result = run_estimator(x, y)
+        a_to_b = result["information_imbalance_a_to_b"]
+        b_to_a = result["information_imbalance_b_to_a"]
+
+        assert b_to_a > a_to_b
+
+    def test_identical_views_match_expected_minimum(self, run_estimator):
+        n = 64
+        x = torch.randn(n, 8)
+        result = run_estimator(x, x.clone())
+        expected = torch.tensor(2.0 / n, dtype=torch.float32)
+
+        assert torch.isclose(result["information_imbalance_a_to_b"], expected, atol=1e-6)
+        assert torch.isclose(result["information_imbalance_b_to_a"], expected, atol=1e-6)
+
+    @pytest.mark.parametrize(
+        ("x_shape", "y_shape"),
+        [
+            ((1, 10, 8), (1, 10, 6)),
+            ((5, 10, 8), (5, 10, 6)),
+            ((2, 3, 10, 8), (2, 3, 10, 6)),
+        ],
+        ids=["1x10", "5x10", "2x3x10"],
+    )
+    def test_batch_shape_preservation(self, run_estimator, x_shape, y_shape):
+        x = torch.randn(*x_shape)
+        y = torch.randn(*y_shape)
+        batch_size = x_shape[:-2]
+
+        result = run_estimator(x, y, batch_size=batch_size)
+
+        assert result["information_imbalance_a_to_b"].shape == batch_size
+        assert result["information_imbalance_b_to_a"].shape == batch_size
+
+    def test_empty_flattened_batch_returns_empty_output(self, run_estimator):
+        x = torch.randn(2, 0, 10, 8)
+        y = torch.randn(2, 0, 10, 6)
+
+        result = run_estimator(x, y, batch_size=[2, 0])
+
+        assert result["information_imbalance_a_to_b"].shape == (2, 0)
+        assert result["information_imbalance_b_to_a"].shape == (2, 0)
+        assert result["information_imbalance_a_to_b"].dtype == torch.float32
+        assert result["information_imbalance_b_to_a"].dtype == torch.float32
+
+    def test_mismatched_sample_counts_raise(self, run_estimator):
+        with pytest.raises(ValueError, match="matching sample counts"):
+            run_estimator(torch.randn(32, 8), torch.randn(31, 6))
+
+    def test_mismatched_batch_shapes_raise(self, run_estimator):
+        with pytest.raises(ValueError, match="matching batch shapes"):
+            run_estimator(torch.randn(2, 3, 16, 8), torch.randn(2, 4, 16, 6), batch_size=[2])
+
+    def test_invalid_rank_raises(self, run_estimator):
+        with pytest.raises(ValueError, match=r"shape \(N, D\) or \(\.\.\., N, D\)"):
+            run_estimator(torch.randn(32), torch.randn(32))
+
+    def test_mismatched_devices_raise(self, run_estimator):
+        x = torch.randn(32, 8)
+        y = torch.randn(32, 6, device="meta")
+
+        with pytest.raises(ValueError, match="same device"):
+            run_estimator(x, y)
+
+    def test_at_least_two_samples_required(self, run_estimator):
+        with pytest.raises(ValueError, match="at least 2 samples"):
+            run_estimator(torch.randn(1, 4), torch.randn(1, 3))
+
+    def test_integer_inputs_are_promoted_to_float32(self, run_estimator):
+        x = torch.arange(128, dtype=torch.int64).reshape(64, 2)
+        y = torch.arange(192, dtype=torch.int64).reshape(64, 3)
+
+        result = run_estimator(x, y)
+        assert result["information_imbalance_a_to_b"].dtype == torch.float32
+        assert result["information_imbalance_b_to_a"].dtype == torch.float32
+
+    def test_determinism(self, run_estimator):
+        x = torch.randn(96, 10)
+        y = torch.randn(96, 7)
+        r1 = run_estimator(x.clone(), y.clone())
+        r2 = run_estimator(x.clone(), y.clone())
+
+        assert torch.allclose(
+            r1["information_imbalance_a_to_b"],
+            r2["information_imbalance_a_to_b"],
+            equal_nan=True,
+        )
+        assert torch.allclose(
+            r1["information_imbalance_b_to_a"],
+            r2["information_imbalance_b_to_a"],
+            equal_nan=True,
+        )
+
+    def test_repr(self):
+        est = InformationImbalanceEstimator()
+        r = repr(est)
+
+        assert "InformationImbalanceEstimator" in r
+        assert "in_keys=['data_a', 'data_b']" in r
+        assert "out_keys=['information_imbalance_a_to_b', 'information_imbalance_b_to_a']" in r
+        assert "p=2.0" in r


### PR DESCRIPTION
## What does this PR do?

Key insights about the PR.

## Linked Issues

- Linked to #34 

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/Xmaster6y/tdhook/blob/main/CONTRIBUTING.md) guide.
- [ ] I have added tests for my changes if needed.
- [ ] I have updated the documentation if needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `InformationImbalanceEstimator` for directional representation similarity using nearest-neighbor ranks, addressing #34. Exposes it in `tdhook.latent`, updates the representation similarity notebook with an Information Imbalance section, and adds tests.

- **New Features**
  - Introduces `tdhook.latent.representation_similarity.InformationImbalanceEstimator` computing `A→B` and `B→A` from nearest-neighbor rank preservation.
  - Supports `(N, D)` and batched `(..., N, D)`, configurable `p`, dtype promotion, and input validation (matching batch shapes/devices, `N≥2`).
  - Exported via `tdhook.latent` and `tdhook.latent.representation_similarity`; notebook adds examples and API notes alongside `CkaEstimator`.
  - Tests cover custom keys, batching, determinism, dtype promotion, and error cases.

<sup>Written for commit a38cf63faec724b1b66045a48cdba2986eb730e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

