### PR TITLE
[Chore] `v0.1.3` release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,6 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it as below.
 type: software
 title: "tdhook"
+version: 0.1.3
+date-released: 2026-04-16
 authors:
   - family-names: Poupart
     given-names: Yoann

--- a/docs/source/_static/switcher.json
+++ b/docs/source/_static/switcher.json
@@ -1,5 +1,9 @@
 [
   {
+    "version": "0.1.3",
+    "url": "https://tdhook.readthedocs.io/en/0.1.3/"
+  },
+  {
     "version": "0.1.2",
     "url": "https://tdhook.readthedocs.io/en/0.1.2/"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tdhook"
-version = "0.1.3.dev0"
+version = "0.1.3"
 description = "Interpretability with tensordict and torch hooks."
 readme = "README.md"
 license = "MIT"

--- a/skills/tdhook/SKILL.md
+++ b/skills/tdhook/SKILL.md
@@ -197,7 +197,6 @@ Colab dev setup: see [tutorials.md](references/tutorials.md) Setup section.
 | [references/api.md](references/api.md) | Full API: HookedModule, methods by category |
 | [references/tutorials.md](references/tutorials.md) | Use-case tutorials |
 | [references/issues.md](references/issues.md) | GitHub issues & solutions |
-| [references/releases.md](references/releases.md) | Version history |
 | [references/file_structure.md](references/file_structure.md) | Codebase navigation |
 
-**Official docs**: [Home](https://tdhook.readthedocs.io/en/latest/) · [Methods](https://tdhook.readthedocs.io/en/latest/methods.html) · [Tutorials](https://tdhook.readthedocs.io/en/latest/tutorials.html) · [API Reference](https://tdhook.readthedocs.io/en/latest/api/index.html)
+**Official docs**: [Home](https://tdhook.readthedocs.io/en/latest/) · [Methods](https://tdhook.readthedocs.io/en/latest/methods.html) · [Tutorials](https://tdhook.readthedocs.io/en/latest/tutorials.html) · [API Reference](https://tdhook.readthedocs.io/en/latest/api/index.html) · [Releases](https://github.com/Xmaster6y/tdhook/releases)

--- a/skills/tdhook/references/README.md
+++ b/skills/tdhook/references/README.md
@@ -9,7 +9,7 @@ Deep documentation for the tdhook skill. See [SKILL.md](../SKILL.md) for the qui
 | Full API (patterns, method implementations) | [api.md](api.md) |
 | Step-by-step use-case tutorials | [tutorials.md](tutorials.md) |
 | GitHub issues & solutions | [issues.md](issues.md) |
-| Version history & breaking changes | [releases.md](releases.md) |
+| Version history & breaking changes | [GitHub Releases](https://github.com/Xmaster6y/tdhook/releases) |
 | Codebase navigation | [file_structure.md](file_structure.md) |
 
 ## Official Documentation

--- a/skills/tdhook/references/releases.md
+++ b/skills/tdhook/references/releases.md
@@ -1,7 +1,0 @@
-# Version History & Breaking Changes
-
-Release notes and notable changes. Full history: [GitHub Releases](https://github.com/Xmaster6y/tdhook/releases).
-
-## Current
-
-**0.1.3.dev0** (dev) – Development version.

--- a/uv.lock
+++ b/uv.lock
@@ -4143,7 +4143,7 @@ wheels = [
 
 [[package]]
 name = "tdhook"
-version = "0.1.3.dev0"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "tensordict" },


### PR DESCRIPTION
## What does this PR do?

Key insights about the PR.

## Linked Issues

- Closes #?
- #?

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/Xmaster6y/tdhook/blob/main/CONTRIBUTING.md) guide.
- [ ] I have added tests for my changes if needed.
- [ ] I have updated the documentation if needed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare v0.1.3 release of `tdhook`, promoting from dev to stable and aligning metadata. Added 0.1.3 to the docs version switcher, set `CITATION.cff` version/date, and replaced the in-repo releases page with a link to GitHub Releases.

<sup>Written for commit e3c098d2224968b04a5a7ae9737316bab151db0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

