### PR TITLE
Add minimal sequential TensorDict pipeline API

### DIFF
--- a/docs/source/composition.rst
+++ b/docs/source/composition.rst
@@ -1,6 +1,35 @@
 Composition contract
 ====================
 
+Sequential pipelines
+--------------------
+
+For workflows that need more than one model execution, use
+``tdhook.pipeline.Pipeline``.  A pipeline is an ordered list of stages with
+explicit TensorDict input and output keys; it is intentionally not a DAG
+scheduler and never converts artifacts implicitly.  ``MethodStage`` adapts an
+existing ``HookingContextFactory`` and runs the model once, while
+``TransformStage`` applies a TensorDict-to-TensorDict function.  Pipeline
+preflight checks dependencies and output collisions before it runs a model.
+
+.. code-block:: python
+
+   from tdhook.contexts import HookingContextFactory
+   from tdhook.pipeline import MethodStage, Pipeline, TransformStage
+
+   pipeline = Pipeline([
+       MethodStage("method", HookingContextFactory(),
+                   required_keys=["input"], provided_keys=["output"]),
+       TransformStage("summary", lambda td: td.set("mean", td["output"].mean(-1)),
+                      required_keys=["output"], provided_keys=["mean"]),
+   ])
+   result = pipeline.run(model, artifacts)
+   final_artifacts = result.artifacts
+
+Every method stage uses the same ``with factory.prepare(model)`` lifecycle as
+standalone code.  Context cleanup is therefore guaranteed if setup or a later
+stage raises.
+
 .. note::
 
    This is the Phase 0 architecture decision for `issue 57

--- a/src/tdhook/__init__.py
+++ b/src/tdhook/__init__.py
@@ -16,4 +16,5 @@ __all__ = [
     "attribution",
     "auto",
     "weights",
+    "pipeline",
 ]

--- a/src/tdhook/contexts.py
+++ b/src/tdhook/contexts.py
@@ -64,18 +64,28 @@ class HookingContext:
             self._hooked_module = self._spawn(prep_module, self, self._extra_relative_path)
             self._handle = self._hook(self._hooked_module)
             return self._hooked_module
-        except Exception:
+        except BaseException:
+            self._abort_enter(prepared)
+            raise
+
+    def _abort_enter(self, prepared: bool) -> None:
+        """Undo a partially-entered context without allowing one cleanup failure to skip another."""
+        try:
             if self._handle is not None:
                 self._handle.remove()
-            if prepared:
-                self._restore(self._module, self._in_keys, self._out_keys, self._extra_relative_path)
-            if self._stack is not None:
-                self._stack.__exit__(None, None, None)
-            self._in_context = False
-            self._hooked_module = None
-            self._handle = None
-            self._stack = None
-            raise
+        finally:
+            try:
+                if prepared:
+                    self._restore(self._module, self._in_keys, self._out_keys, self._extra_relative_path)
+            finally:
+                try:
+                    if self._stack is not None:
+                        self._stack.__exit__(None, None, None)
+                finally:
+                    self._in_context = False
+                    self._hooked_module = None
+                    self._handle = None
+                    self._stack = None
 
     def __enter__(self):
         return self._enter(managed_by_context_manager=True)

--- a/src/tdhook/contexts.py
+++ b/src/tdhook/contexts.py
@@ -51,26 +51,47 @@ class HookingContext:
         self._managed_by_context_manager = managed_by_context_manager
 
         working_module = self._module
-        with ExitStack() as stack:
-            for factory in self._pre_factories:
-                working_module = stack.enter_context(factory.prepare(working_module, self._in_keys, self._out_keys))
-            self._stack = stack.pop_all()
-
-        prep_module = self._prepare(working_module, self._in_keys, self._out_keys, self._extra_relative_path)
-        self._hooked_module = self._spawn(prep_module, self, self._extra_relative_path)
-        self._handle = self._hook(self._hooked_module)
-        return self._hooked_module
+        prepared = False
+        try:
+            with ExitStack() as stack:
+                for factory in self._pre_factories:
+                    working_module = stack.enter_context(
+                        factory.prepare(working_module, self._in_keys, self._out_keys)
+                    )
+                self._stack = stack.pop_all()
+            prep_module = self._prepare(working_module, self._in_keys, self._out_keys, self._extra_relative_path)
+            prepared = True
+            self._hooked_module = self._spawn(prep_module, self, self._extra_relative_path)
+            self._handle = self._hook(self._hooked_module)
+            return self._hooked_module
+        except Exception:
+            if self._handle is not None:
+                self._handle.remove()
+            if prepared:
+                self._restore(self._module, self._in_keys, self._out_keys, self._extra_relative_path)
+            if self._stack is not None:
+                self._stack.__exit__(None, None, None)
+            self._in_context = False
+            self._hooked_module = None
+            self._handle = None
+            self._stack = None
+            raise
 
     def __enter__(self):
         return self._enter(managed_by_context_manager=True)
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self._handle.remove()
-        self._restore(self._module, self._in_keys, self._out_keys, self._extra_relative_path)
-        self._in_context = False
-        self._hooked_module = None
-        self._handle = None
-        self._stack.__exit__(exc_type, exc_value, traceback)
+        try:
+            if self._handle is not None:
+                self._handle.remove()
+            self._restore(self._module, self._in_keys, self._out_keys, self._extra_relative_path)
+        finally:
+            self._in_context = False
+            self._hooked_module = None
+            self._handle = None
+            if self._stack is not None:
+                self._stack.__exit__(exc_type, exc_value, traceback)
+                self._stack = None
 
     @contextmanager
     def disable_hooks(self) -> Generator[None, None, None]:

--- a/src/tdhook/pipeline.py
+++ b/src/tdhook/pipeline.py
@@ -1,0 +1,210 @@
+"""A small, linear API for TensorDict interpretability workflows.
+
+Pipelines make the data exchanged between independently executed methods
+explicit.  They deliberately do not schedule a graph or convert artifacts:
+each stage receives the same :class:`~tensordict.TensorDict` and declares the
+keys it reads and writes.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Callable, Iterable, Sequence
+
+from torch import nn
+from tensordict import TensorDictBase
+
+from tdhook._types import UnraveledKey
+from tdhook.contexts import HookingContextFactory
+
+
+PipelineKey = UnraveledKey
+RESERVED_KEYS = frozenset({"_pipeline"})
+
+
+def _keys(keys: Iterable[PipelineKey]) -> tuple[PipelineKey, ...]:
+    result = tuple(keys)
+    for key in result:
+        if not isinstance(key, UnraveledKey):
+            raise TypeError(f"Pipeline keys must be strings or non-empty tuples of strings, got {key!r}")
+    if len(set(result)) != len(result):
+        raise ValueError(f"Stage declares duplicate keys: {result!r}")
+    return result
+
+
+@dataclass(frozen=True)
+class StageResult:
+    """Metadata recorded for one completed stage."""
+
+    name: str
+    provided_keys: tuple[PipelineKey, ...]
+    effects: frozenset[str]
+
+
+@dataclass(frozen=True)
+class PipelineResult:
+    """Final artifacts and metadata from a pipeline execution."""
+
+    artifacts: TensorDictBase
+    stages: tuple[StageResult, ...]
+
+
+class Stage(ABC):
+    """One ordered pipeline operation with an explicit artifact contract."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        required_keys: Iterable[PipelineKey] = (),
+        provided_keys: Iterable[PipelineKey] = (),
+        effects: Iterable[str] = (),
+        incompatible_effects: Iterable[str] = (),
+    ) -> None:
+        if not name:
+            raise ValueError("A stage must have a non-empty name")
+        self.name = name
+        self.required_keys = _keys(required_keys)
+        self.provided_keys = _keys(provided_keys)
+        self.effects = frozenset(effects)
+        self.incompatible_effects = frozenset(incompatible_effects)
+
+    @abstractmethod
+    def run(self, model: nn.Module, artifacts: TensorDictBase) -> TensorDictBase:
+        """Execute the stage and return its TensorDict artifacts."""
+
+
+class MethodStage(Stage):
+    """Execute a model once under an existing :class:`HookingContextFactory`."""
+
+    def __init__(
+        self,
+        name: str,
+        factory: HookingContextFactory,
+        *,
+        required_keys: Iterable[PipelineKey],
+        provided_keys: Iterable[PipelineKey],
+        effects: Iterable[str] = (),
+        incompatible_effects: Iterable[str] = (),
+    ) -> None:
+        super().__init__(
+            name,
+            required_keys=required_keys,
+            provided_keys=provided_keys,
+            effects=("model_execution", *effects),
+            incompatible_effects=incompatible_effects,
+        )
+        self.factory = factory
+
+    def run(self, model: nn.Module, artifacts: TensorDictBase) -> TensorDictBase:
+        with self.factory.prepare(
+            model, in_keys=list(self.required_keys), out_keys=list(self.provided_keys)
+        ) as method:
+            result = method(artifacts)
+        return artifacts if result is None else result
+
+
+class TransformStage(Stage):
+    """Apply a pure TensorDict-to-TensorDict transformation."""
+
+    def __init__(
+        self,
+        name: str,
+        transform: Callable[[TensorDictBase], TensorDictBase],
+        *,
+        required_keys: Iterable[PipelineKey] = (),
+        provided_keys: Iterable[PipelineKey] = (),
+        effects: Iterable[str] = (),
+        incompatible_effects: Iterable[str] = (),
+    ) -> None:
+        super().__init__(
+            name,
+            required_keys=required_keys,
+            provided_keys=provided_keys,
+            effects=effects,
+            incompatible_effects=incompatible_effects,
+        )
+        self.transform = transform
+
+    def run(self, model: nn.Module, artifacts: TensorDictBase) -> TensorDictBase:
+        result = self.transform(artifacts)
+        if not isinstance(result, TensorDictBase):
+            raise TypeError(f"Transform stage {self.name!r} must return a TensorDict, got {type(result).__name__}")
+        return result
+
+
+class Pipeline:
+    """Validate and execute an ordered sequence of stages."""
+
+    def __init__(self, stages: Sequence[Stage], *, reserved_keys: Iterable[PipelineKey] = RESERVED_KEYS) -> None:
+        self.stages = tuple(stages)
+        self.reserved_keys = frozenset(_keys(reserved_keys))
+        self._validate_static()
+
+    def _validate_static(self) -> None:
+        names = [stage.name for stage in self.stages]
+        if len(set(names)) != len(names):
+            raise ValueError("Pipeline stage names must be unique")
+        produced: dict[PipelineKey, str] = {}
+        effects: dict[str, str] = {}
+        incompatible_effects: dict[str, str] = {}
+        for stage in self.stages:
+            incompatible = stage.incompatible_effects.intersection(effects)
+            if incompatible:
+                effect = sorted(incompatible)[0]
+                raise ValueError(
+                    f"Stage {stage.name!r} is incompatible with effect {effect!r} from {effects[effect]!r}"
+                )
+            reverse_incompatible = stage.effects.intersection(incompatible_effects)
+            if reverse_incompatible:
+                effect = sorted(reverse_incompatible)[0]
+                raise ValueError(
+                    f"Stage {stage.name!r} conflicts with incompatible effect {effect!r} from "
+                    f"{incompatible_effects[effect]!r}"
+                )
+            effects.update({effect: stage.name for effect in stage.effects})
+            incompatible_effects.update({effect: stage.name for effect in stage.incompatible_effects})
+            for key in stage.provided_keys:
+                if key in self.reserved_keys:
+                    raise ValueError(f"Stage {stage.name!r} writes reserved pipeline key {key!r}")
+                if key in produced:
+                    raise ValueError(
+                        f"Stage {stage.name!r} duplicates output key {key!r} already provided by {produced[key]!r}"
+                    )
+                produced[key] = stage.name
+
+    @staticmethod
+    def _artifact_keys(artifacts: TensorDictBase) -> set[PipelineKey]:
+        return set(artifacts.keys(include_nested=True, leaves_only=True))
+
+    def validate(self, artifacts: TensorDictBase) -> None:
+        """Fail before model execution when a stage dependency is unavailable."""
+        if not isinstance(artifacts, TensorDictBase):
+            raise TypeError(f"Pipeline artifacts must be a TensorDict, got {type(artifacts).__name__}")
+        available = self._artifact_keys(artifacts)
+        for stage in self.stages:
+            missing = [key for key in stage.required_keys if key not in available]
+            if missing:
+                raise ValueError(f"Stage {stage.name!r} requires missing artifact keys: {missing!r}")
+            collisions = [key for key in stage.provided_keys if key in available]
+            if collisions:
+                raise ValueError(f"Stage {stage.name!r} writes existing artifact keys: {collisions!r}")
+            available.update(stage.provided_keys)
+
+    def run(self, model: nn.Module, artifacts: TensorDictBase) -> PipelineResult:
+        self.validate(artifacts)
+        stage_results: list[StageResult] = []
+        current = artifacts
+        for stage in self.stages:
+            try:
+                current = stage.run(model, current)
+            except Exception as error:
+                raise RuntimeError(f"Pipeline stage {stage.name!r} failed: {error}") from error
+            if not isinstance(current, TensorDictBase):
+                raise TypeError(f"Stage {stage.name!r} returned {type(current).__name__}, not a TensorDict")
+            missing = [key for key in stage.provided_keys if key not in self._artifact_keys(current)]
+            if missing:
+                raise ValueError(f"Stage {stage.name!r} did not provide declared artifact keys: {missing!r}")
+            stage_results.append(StageResult(stage.name, stage.provided_keys, stage.effects))
+        return PipelineResult(current, tuple(stage_results))

--- a/src/tdhook/pipeline.py
+++ b/src/tdhook/pipeline.py
@@ -33,6 +33,16 @@ def _keys(keys: Iterable[PipelineKey]) -> tuple[PipelineKey, ...]:
     return result
 
 
+def _path(key: PipelineKey) -> tuple[str, ...]:
+    return (key,) if isinstance(key, str) else key
+
+
+def _keys_conflict(first: PipelineKey, second: PipelineKey) -> bool:
+    """Whether two TensorDict keys are identical or ancestor/descendant paths."""
+    first_path, second_path = _path(first), _path(second)
+    return first_path[: len(second_path)] == second_path or second_path[: len(first_path)] == first_path
+
+
 @dataclass(frozen=True)
 class StageResult:
     """Metadata recorded for one completed stage."""
@@ -87,6 +97,8 @@ class MethodStage(Stage):
         provided_keys: Iterable[PipelineKey],
         effects: Iterable[str] = (),
         incompatible_effects: Iterable[str] = (),
+        model_in_keys: Iterable[PipelineKey] | None = None,
+        model_out_keys: Iterable[PipelineKey] | None = None,
     ) -> None:
         super().__init__(
             name,
@@ -96,10 +108,14 @@ class MethodStage(Stage):
             incompatible_effects=incompatible_effects,
         )
         self.factory = factory
+        self.model_in_keys = None if model_in_keys is None else _keys(model_in_keys)
+        self.model_out_keys = None if model_out_keys is None else _keys(model_out_keys)
 
     def run(self, model: nn.Module, artifacts: TensorDictBase) -> TensorDictBase:
         with self.factory.prepare(
-            model, in_keys=list(self.required_keys), out_keys=list(self.provided_keys)
+            model,
+            in_keys=None if self.model_in_keys is None else list(self.model_in_keys),
+            out_keys=None if self.model_out_keys is None else list(self.model_out_keys),
         ) as method:
             result = method(artifacts)
         return artifacts if result is None else result
@@ -166,17 +182,19 @@ class Pipeline:
             effects.update({effect: stage.name for effect in stage.effects})
             incompatible_effects.update({effect: stage.name for effect in stage.incompatible_effects})
             for key in stage.provided_keys:
-                if key in self.reserved_keys:
+                if any(_keys_conflict(key, reserved_key) for reserved_key in self.reserved_keys):
                     raise ValueError(f"Stage {stage.name!r} writes reserved pipeline key {key!r}")
-                if key in produced:
+                conflicting_key = next((output for output in produced if _keys_conflict(key, output)), None)
+                if conflicting_key is not None:
                     raise ValueError(
-                        f"Stage {stage.name!r} duplicates output key {key!r} already provided by {produced[key]!r}"
+                        f"Stage {stage.name!r} duplicates output key {key!r} already provided by "
+                        f"{produced[conflicting_key]!r}"
                     )
                 produced[key] = stage.name
 
     @staticmethod
     def _artifact_keys(artifacts: TensorDictBase) -> set[PipelineKey]:
-        return set(artifacts.keys(include_nested=True, leaves_only=True))
+        return set(artifacts.keys(include_nested=True, leaves_only=False))
 
     def validate(self, artifacts: TensorDictBase) -> None:
         """Fail before model execution when a stage dependency is unavailable."""
@@ -187,7 +205,9 @@ class Pipeline:
             missing = [key for key in stage.required_keys if key not in available]
             if missing:
                 raise ValueError(f"Stage {stage.name!r} requires missing artifact keys: {missing!r}")
-            collisions = [key for key in stage.provided_keys if key in available]
+            collisions = [
+                key for key in stage.provided_keys if any(_keys_conflict(key, existing) for existing in available)
+            ]
             if collisions:
                 raise ValueError(f"Stage {stage.name!r} writes existing artifact keys: {collisions!r}")
             available.update(stage.provided_keys)
@@ -197,6 +217,9 @@ class Pipeline:
         stage_results: list[StageResult] = []
         current = artifacts
         for stage in self.stages:
+            missing = [key for key in stage.required_keys if key not in self._artifact_keys(current)]
+            if missing:
+                raise ValueError(f"Stage {stage.name!r} requires missing artifact keys: {missing!r}")
             try:
                 current = stage.run(model, current)
             except Exception as error:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -5,7 +5,7 @@ from tensordict import TensorDict
 from tdhook.contexts import HookingContextFactory
 from tdhook.hooks import MultiHookHandle
 from tdhook.modules import HookedModule
-from tdhook.pipeline import MethodStage, Pipeline, TransformStage
+from tdhook.pipeline import MethodStage, Pipeline, Stage, TransformStage
 
 
 class AddOne(HookingContextFactory):
@@ -81,6 +81,52 @@ def test_duplicate_outputs_and_reserved_keys_are_rejected():
                 TransformStage("reader", lambda td: td, incompatible_effects=["writes_model"]),
             ]
         )
+
+
+def test_stage_contract_validation_errors():
+    with pytest.raises(ValueError, match="non-empty"):
+        TransformStage("", lambda td: td)
+    with pytest.raises(TypeError, match="Pipeline keys"):
+        TransformStage("bad-key", lambda td: td, required_keys=[1])
+    with pytest.raises(ValueError, match="duplicate keys"):
+        TransformStage("duplicate-key", lambda td: td, provided_keys=["output", "output"])
+    with pytest.raises(ValueError, match="stage names"):
+        Pipeline([TransformStage("same", lambda td: td), TransformStage("same", lambda td: td)])
+    with pytest.raises(ValueError, match="writer.*reads_model.*reader"):
+        Pipeline(
+            [
+                TransformStage("reader", lambda td: td, incompatible_effects=["reads_model"]),
+                TransformStage("writer", lambda td: td, effects=["reads_model"]),
+            ]
+        )
+
+
+def test_pipeline_reports_input_output_and_transform_contract_errors(default_test_model):
+    pipeline = Pipeline([TransformStage("transform", lambda td: "not a tensordict")])
+    with pytest.raises(RuntimeError, match="transform.*must return a TensorDict"):
+        pipeline.run(default_test_model, TensorDict({}, batch_size=[]))
+
+    with pytest.raises(TypeError, match="artifacts must be a TensorDict"):
+        pipeline.validate({})
+
+    collision = Pipeline([TransformStage("collision", lambda td: td, provided_keys=["input"])])
+    with pytest.raises(ValueError, match="collision.*existing artifact keys.*input"):
+        collision.run(default_test_model, TensorDict({"input": torch.ones(1)}, batch_size=[1]))
+
+    missing_output = Pipeline([TransformStage("missing-output", lambda td: td, provided_keys=["output"])])
+    with pytest.raises(ValueError, match="missing-output.*did not provide.*output"):
+        missing_output.run(default_test_model, TensorDict({}, batch_size=[]))
+
+
+class InvalidResultStage(Stage):
+    def run(self, model, artifacts):
+        return "not a tensordict"
+
+
+def test_pipeline_rejects_a_stage_that_returns_non_tensordict(default_test_model):
+    pipeline = Pipeline([InvalidResultStage("invalid")])
+    with pytest.raises(TypeError, match="invalid.*not a TensorDict"):
+        pipeline.run(default_test_model, TensorDict({}, batch_size=[]))
 
 
 class FailingPrepare(HookingContextFactory):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
 
 from tdhook.contexts import HookingContextFactory
 from tdhook.hooks import MultiHookHandle
@@ -53,6 +54,28 @@ def test_transform_then_method_with_nested_key(default_test_model):
     assert torch.allclose(result.artifacts["output"], default_test_model(torch.ones(2, 10) * 2))
 
 
+def test_method_stage_keeps_artifact_contract_separate_from_model_signature(default_test_model):
+    model = TensorDictModule(default_test_model, in_keys=["model_input"], out_keys=["prediction"])
+    artifacts = TensorDict({"model_input": torch.ones(2, 10), "baseline": torch.zeros(2, 10)}, batch_size=[2])
+    pipeline = Pipeline(
+        [
+            MethodStage(
+                "predict",
+                HookingContextFactory(),
+                required_keys=["model_input", "baseline"],
+                provided_keys=["prediction"],
+                model_in_keys=["model_input"],
+                model_out_keys=["prediction"],
+            )
+        ]
+    )
+
+    result = pipeline.run(model, artifacts)
+
+    assert "baseline" in result.artifacts
+    assert torch.allclose(result.artifacts["prediction"], default_test_model(artifacts["model_input"]))
+
+
 def test_invalid_dependencies_fail_before_model_execution(default_test_model):
     called = False
 
@@ -74,6 +97,13 @@ def test_duplicate_outputs_and_reserved_keys_are_rejected():
         Pipeline([first, second])
     with pytest.raises(ValueError, match="reserved pipeline key"):
         Pipeline([TransformStage("bad", lambda td: td, provided_keys=["_pipeline"])])
+    with pytest.raises(ValueError, match="duplicates output key.*report.*first"):
+        Pipeline(
+            [
+                TransformStage("first", lambda td: td, provided_keys=["report"]),
+                TransformStage("second", lambda td: td, provided_keys=[("report", "mean")]),
+            ]
+        )
     with pytest.raises(ValueError, match="reader.*writes_model.*writer"):
         Pipeline(
             [
@@ -113,6 +143,10 @@ def test_pipeline_reports_input_output_and_transform_contract_errors(default_tes
     with pytest.raises(ValueError, match="collision.*existing artifact keys.*input"):
         collision.run(default_test_model, TensorDict({"input": torch.ones(1)}, batch_size=[1]))
 
+    nested_collision = Pipeline([TransformStage("collision", lambda td: td, provided_keys=["report"])])
+    with pytest.raises(ValueError, match="collision.*existing artifact keys.*report"):
+        nested_collision.run(default_test_model, TensorDict({"report": {"mean": torch.ones(1)}}, batch_size=[1]))
+
     missing_output = Pipeline([TransformStage("missing-output", lambda td: td, provided_keys=["output"])])
     with pytest.raises(ValueError, match="missing-output.*did not provide.*output"):
         missing_output.run(default_test_model, TensorDict({}, batch_size=[]))
@@ -129,6 +163,18 @@ def test_pipeline_rejects_a_stage_that_returns_non_tensordict(default_test_model
         pipeline.run(default_test_model, TensorDict({}, batch_size=[]))
 
 
+def test_pipeline_rechecks_requirements_after_a_transform(default_test_model):
+    pipeline = Pipeline(
+        [
+            TransformStage("remove-input", lambda td: td.del_("input"), required_keys=["input"]),
+            TransformStage("needs-input", lambda td: td, required_keys=["input"]),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="needs-input.*missing artifact keys.*input"):
+        pipeline.run(default_test_model, TensorDict({"input": torch.ones(1)}, batch_size=[1]))
+
+
 class FailingPrepare(HookingContextFactory):
     def _prepare_module(self, module, in_keys, out_keys, extra_relative_path):
         module.pipeline_setup_flag = True
@@ -142,6 +188,16 @@ class FailingPrepare(HookingContextFactory):
         raise RuntimeError("hook setup failed")
 
 
+class InterruptingPrepare(FailingPrepare):
+    def _hook_module(self, module):
+        raise KeyboardInterrupt("interrupted")
+
+
+class FailingCleanup(FailingPrepare):
+    def _restore_module(self, module, in_keys, out_keys, extra_relative_path):
+        raise RuntimeError("restore failed")
+
+
 def test_context_cleanup_on_method_setup_and_execution_failure(default_test_model):
     setup = Pipeline([MethodStage("setup", FailingPrepare(), required_keys=["input"], provided_keys=["output"])])
     with pytest.raises(RuntimeError, match="setup.*hook setup failed"):
@@ -151,3 +207,42 @@ def test_context_cleanup_on_method_setup_and_execution_failure(default_test_mode
     execute = Pipeline([TransformStage("explode", lambda td: (_ for _ in ()).throw(RuntimeError("boom")))])
     with pytest.raises(RuntimeError, match="explode.*boom"):
         execute.run(default_test_model, TensorDict({}, batch_size=[]))
+
+
+def test_context_cleanup_handles_interrupts_and_cleanup_errors(default_test_model):
+    interrupted = Pipeline(
+        [MethodStage("interrupt", InterruptingPrepare(), required_keys=["input"], provided_keys=["output"])]
+    )
+    with pytest.raises(KeyboardInterrupt, match="interrupted"):
+        interrupted.run(default_test_model, TensorDict({"input": torch.ones(2, 10)}, batch_size=[2]))
+    assert not hasattr(default_test_model, "pipeline_setup_flag")
+
+    class Handle:
+        removed = False
+
+        def remove(self):
+            self.removed = True
+
+    class Stack:
+        exited = False
+
+        def __exit__(self, *args):
+            self.exited = True
+
+    context = AddOne().prepare(default_test_model)
+    handle, stack = Handle(), Stack()
+    context._handle = handle
+    context._stack = stack
+    context._in_context = True
+    context._abort_enter(prepared=False)
+    assert not context._in_context
+    assert context._handle is None
+    assert handle.removed
+    assert stack.exited
+
+    context = FailingCleanup().prepare(default_test_model)
+    with pytest.raises(RuntimeError, match="restore failed"):
+        context.__enter__()
+    assert not context._in_context
+    assert context._handle is None
+    assert context._hooked_module is None

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,107 @@
+import pytest
+import torch
+from tensordict import TensorDict
+
+from tdhook.contexts import HookingContextFactory
+from tdhook.hooks import MultiHookHandle
+from tdhook.modules import HookedModule
+from tdhook.pipeline import MethodStage, Pipeline, TransformStage
+
+
+class AddOne(HookingContextFactory):
+    def _hook_module(self, module: HookedModule) -> MultiHookHandle:
+        return module.register_submodule_hook("", lambda module, args, output: output + 1, direction="fwd")
+
+
+def test_method_then_transform(default_test_model):
+    artifacts = TensorDict({"input": torch.ones(2, 10)}, batch_size=[2])
+    pipeline = Pipeline(
+        [
+            MethodStage("predict", AddOne(), required_keys=["input"], provided_keys=["output"]),
+            TransformStage(
+                "summarise",
+                lambda td: td.set("summary", td["output"].mean(-1)),
+                required_keys=["output"],
+                provided_keys=["summary"],
+            ),
+        ]
+    )
+
+    result = pipeline.run(default_test_model, artifacts)
+
+    assert torch.allclose(result.artifacts["output"], default_test_model(torch.ones(2, 10)) + 1)
+    assert result.artifacts["summary"].shape == (2,)
+    assert [stage.name for stage in result.stages] == ["predict", "summarise"]
+
+
+def test_transform_then_method_with_nested_key(default_test_model):
+    artifacts = TensorDict({"source": {"x": torch.ones(2, 10)}}, batch_size=[2])
+    pipeline = Pipeline(
+        [
+            TransformStage(
+                "prepare",
+                lambda td: td.set("input", td["source", "x"] * 2),
+                required_keys=[("source", "x")],
+                provided_keys=["input"],
+            ),
+            MethodStage("predict", HookingContextFactory(), required_keys=["input"], provided_keys=["output"]),
+        ]
+    )
+
+    result = pipeline.run(default_test_model, artifacts)
+
+    assert torch.allclose(result.artifacts["output"], default_test_model(torch.ones(2, 10) * 2))
+
+
+def test_invalid_dependencies_fail_before_model_execution(default_test_model):
+    called = False
+
+    def transform(td):
+        nonlocal called
+        called = True
+        return td
+
+    pipeline = Pipeline([TransformStage("needs_input", transform, required_keys=["missing"])])
+    with pytest.raises(ValueError, match="needs_input.*missing"):
+        pipeline.run(default_test_model, TensorDict({}, batch_size=[]))
+    assert not called
+
+
+def test_duplicate_outputs_and_reserved_keys_are_rejected():
+    first = TransformStage("first", lambda td: td, provided_keys=["result"])
+    second = TransformStage("second", lambda td: td, provided_keys=["result"])
+    with pytest.raises(ValueError, match="duplicates output key.*result.*first"):
+        Pipeline([first, second])
+    with pytest.raises(ValueError, match="reserved pipeline key"):
+        Pipeline([TransformStage("bad", lambda td: td, provided_keys=["_pipeline"])])
+    with pytest.raises(ValueError, match="reader.*writes_model.*writer"):
+        Pipeline(
+            [
+                TransformStage("writer", lambda td: td, effects=["writes_model"]),
+                TransformStage("reader", lambda td: td, incompatible_effects=["writes_model"]),
+            ]
+        )
+
+
+class FailingPrepare(HookingContextFactory):
+    def _prepare_module(self, module, in_keys, out_keys, extra_relative_path):
+        module.pipeline_setup_flag = True
+        return module
+
+    def _restore_module(self, module, in_keys, out_keys, extra_relative_path):
+        del module.pipeline_setup_flag
+        return module
+
+    def _hook_module(self, module):
+        raise RuntimeError("hook setup failed")
+
+
+def test_context_cleanup_on_method_setup_and_execution_failure(default_test_model):
+    setup = Pipeline([MethodStage("setup", FailingPrepare(), required_keys=["input"], provided_keys=["output"])])
+    with pytest.raises(RuntimeError, match="setup.*hook setup failed"):
+        setup.run(default_test_model, TensorDict({"input": torch.ones(2, 10)}, batch_size=[2]))
+    assert not hasattr(default_test_model, "pipeline_setup_flag")
+
+    execute = Pipeline([TransformStage("explode", lambda td: (_ for _ in ()).throw(RuntimeError("boom")))])
+    with pytest.raises(RuntimeError, match="explode.*boom"):
+        execute.run(default_test_model, TensorDict({}, batch_size=[]))


### PR DESCRIPTION
## Summary

- add explicit linear `Pipeline`, `Stage`, `MethodStage`, `TransformStage`, and `PipelineResult` APIs
- preflight artifact dependencies, duplicate/reserved outputs, and declared incompatible effects before execution
- guarantee HookingContext cleanup when setup fails, while preserving standalone context use
- document the sequential pipeline contract and add end-to-end coverage

## Validation

- `.venv/bin/python -m pytest tests` (410 passed)

Closes #58

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a minimal, sequential `tdhook.pipeline.Pipeline` for multi-step TensorDict workflows with explicit stage contracts, addressing Linear issue #58. It strengthens validation (path-aware key collisions, strict return types, effect conflicts) and hardens context cleanup on setup and interrupt failures.

- **New Features**
  - `Pipeline`, `Stage`, `MethodStage`, `TransformStage`, `PipelineResult` with explicit `required_keys` and `provided_keys`.
  - Preflight checks for missing inputs, path-based output collisions, reserved `_pipeline` keys, and incompatible effects; unique stage names enforced.
  - `MethodStage` supports `model_in_keys`/`model_out_keys` to decouple model signature; auto-tags `model_execution`; verifies declared outputs.

- **Bug Fixes**
  - Robust `HookingContext` cleanup on setup failure, interrupts, and cleanup errors (hooks removed, module restored, stack exited).

<sup>Written for commit 404bf590862f32a33157c5d8ab22cbffd18cce65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Xmaster6y/tdhook/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

