### PR TITLE
Make same-run hook composition path-safe

### DIFF
--- a/docs/source/composition.rst
+++ b/docs/source/composition.rst
@@ -181,6 +181,10 @@ share one execution:
    :class:`SteeringVectors <tdhook.latent.SteeringVectors>`.  They use the
    standard context/module classes and do not wrap the model.
 
+   ``HookGroup`` (also available as ``CompositeHookingContextFactory``) installs
+   children in the order supplied. Reads observe preceding writes in the same
+   direction, and writes are applied in that same deterministic order.
+
 ``wrapped methods``
    Attribution methods, :class:`ActivationAddition
    <tdhook.latent.ActivationAddition>`, and :class:`ActivationPatching
@@ -211,20 +215,21 @@ share one execution:
      - Untested: registration order is deterministic, but cross-method
        conformance and cleanup tests are pending.  Target: promote compatible
        pairs after conformance coverage.
-     - Current blocker: the composite factory does not preserve the wrapped
-       child's relative path.  Target: path-safe composition or a planned stage
-       split.
-     - Current blocker: the generic composite cannot select or merge the
-       required specialised context/module classes.  Target: isolate the
-       specialised stage unless it declares a merge strategy.
+     - Supported for standard-context children: each child resolves paths
+       against the original module after any ordered wrapper rewrites. Setup
+       rolls back prepared children and already-installed hooks on failure.
+     - Unsupported before mutation with a capability diagnostic: specialised
+       context/module requirements need an explicit merge strategy. Use a
+       separate pipeline stage meanwhile.
      - Not applicable: place the operator at a pipeline boundary.
    * - Wrapped methods
-     - Current blocker: the wrapped child's relative path is lost.  Target:
-       path-safe composition or a planned stage split.
-     - Current blocker: child wrappers and relative paths are not merged.
-       Target: merge compatible wrappers and split the rest.
-     - Current blocker: wrapper and specialised context/module requirements are
-       not merged.  Target: an explicit merge strategy or stage isolation.
+     - Supported for standard-context children; relative paths are rebased to
+       the original module after wrapper rewrites.
+     - Supported when both wrappers retain the original module and use the
+       standard shared context/module. Otherwise fail before mutation and
+       split into stages.
+     - Unsupported before mutation with a capability diagnostic; an explicit
+       merge strategy is required.
      - Not applicable: place the operator at a pipeline boundary.
    * - Specialised methods
      - Current blocker: the generic composite rejects the specialised

--- a/src/tdhook/contexts.py
+++ b/src/tdhook/contexts.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from contextlib import ExitStack
 from typing import List, Optional, Generator, Dict, overload, Literal
+from weakref import WeakKeyDictionary
 from torch import nn
 from tensordict.nn import TensorDictModuleBase, TensorDictModule
 from tensordict import TensorDict
@@ -269,6 +270,7 @@ class CompositeHookingContextFactory(HookingContextFactory):
     def __init__(self, *contexts: HookingContextFactory):
         super().__init__()
         self._contexts = contexts
+        self._prepared_children = WeakKeyDictionary()
         self._validate_capabilities()
 
     def _validate_capabilities(self) -> None:
@@ -307,21 +309,24 @@ class CompositeHookingContextFactory(HookingContextFactory):
         extra_relative_path: str,
     ) -> TensorDictModuleBase:
         prepared_contexts = []
+        prepared_modules = []
         original_module = module
         try:
             for context in self._contexts:
                 module = context._prepare_module(module, in_keys, out_keys, extra_relative_path)
                 prepared_contexts.append(context)
+                prepared_modules.append(module)
+            self._prepared_children[module] = prepared_modules
             return module
         except BaseException:
             # A child can mutate the original module before raising.  Restore
             # the failing child as well as every successfully prepared child
             # in reverse order, just as on a normal context exit. Preserve the
             # original exception.
-            for context in reversed([context, *prepared_contexts]):
+            for context in [context, *reversed(prepared_contexts)]:
                 try:
                     context._restore_module(original_module, in_keys, out_keys, extra_relative_path)
-                except BaseException:
+                except Exception:
                     pass
             raise
 
@@ -339,30 +344,37 @@ class CompositeHookingContextFactory(HookingContextFactory):
     def _hook_module(self, module: HookedModule) -> MultiHookHandle:
         handles = []
         try:
-            for context in self._contexts:
-                handles.append(context._hook_module(self._child_module(module)))
+            prepared_children = self._prepared_children.get(module.td_module)
+            if prepared_children is None:
+                raise RuntimeError("Cannot compose hooks: missing prepared child modules")
+            for context, child_module in zip(self._contexts, prepared_children):
+                handles.append(context._hook_module(self._child_module(module, child_module)))
             return MultiHookHandle(handles)
         except BaseException:
             # Hooks registered by earlier children are live immediately.  Do
             # not leave them installed when a later child cannot be installed.
-            MultiHookHandle(handles).remove()
+            for handle in reversed(handles):
+                try:
+                    handle.remove()
+                except Exception:
+                    pass
             raise
 
     @staticmethod
-    def _child_module(module: HookedModule) -> HookedModule:
-        """Give a child a view whose relative root is the original module.
+    def _child_module(module: HookedModule, prepared_module: TensorDictModuleBase) -> HookedModule:
+        """Give a child its own prepared wrapper and original-module root.
 
-        Preparation often wraps the input in a ``TensorDictSequential``.  The
-        original TensorDict module remains an object inside that final wrapper;
-        locating it by identity means every child's paths continue to resolve
-        as they did before composition, independent of the order of rewrites.
+        A child may need state stored on its wrapper (for example, a cache
+        reference) while its hooks must resolve paths relative to the original
+        model. Locating that original module by identity supplies the latter
+        without replacing the former with a later child's wrapper.
         """
         original = module.hooking_context._module
-        for name, candidate in module.td_module.named_modules(remove_duplicate=False):
+        for name, candidate in prepared_module.named_modules(remove_duplicate=False):
             if candidate is original:
                 relative_path = merge_paths("td_module", name, module.hooking_context._extra_relative_path)
                 return HookedModule(
-                    module.td_module, hooking_context=module.hooking_context, relative_path=relative_path
+                    prepared_module, hooking_context=module.hooking_context, relative_path=relative_path
                 )
         raise RuntimeError("Cannot compose hooks: the prepared module no longer contains the original module")
 

--- a/src/tdhook/contexts.py
+++ b/src/tdhook/contexts.py
@@ -269,19 +269,35 @@ class CompositeHookingContextFactory(HookingContextFactory):
     def __init__(self, *contexts: HookingContextFactory):
         super().__init__()
         self._contexts = contexts
-        attributes = ("_spawn_hooked_module", "_hooking_context_class", "_hooked_module_class")
-        composite_overriden = {
-            attr: getattr(type(self), attr) != getattr(HookingContextFactory, attr) for attr in attributes
-        }
-        for context in contexts:
-            for attr in attributes:
-                if (
-                    getattr(type(context), attr) != getattr(HookingContextFactory, attr)
-                    and not composite_overriden[attr]
-                ):
-                    raise ValueError(
-                        f"Cannot compose factories that override {attr}, consider subclassing this factory to override {attr}"
-                    )
+        self._validate_capabilities()
+
+    def _validate_capabilities(self) -> None:
+        """Reject capabilities that cannot be represented by one shared context.
+
+        A same-run group owns one :class:`HookingContext` and one
+        :class:`HookedModule`.  Factories that need a specialised context or
+        wrapper therefore cannot be safely composed yet; failing before any
+        module mutation is preferable to silently giving the child the wrong
+        runtime object.
+        """
+        for context in self._contexts:
+            if type(context)._hooking_context_class is not HookingContext:
+                raise ValueError(
+                    f"Cannot compose {type(context).__name__}: it requires the specialised "
+                    f"{type(context)._hooking_context_class.__name__} capability. "
+                    "Same-run composition currently supports factories using HookingContext."
+                )
+            if type(context)._hooked_module_class is not HookedModule:
+                raise ValueError(
+                    f"Cannot compose {type(context).__name__}: it requires the specialised "
+                    f"{type(context)._hooked_module_class.__name__} capability. "
+                    "Same-run composition currently supports factories using HookedModule."
+                )
+            if type(context)._spawn_hooked_module is not HookingContextFactory._spawn_hooked_module:
+                raise ValueError(
+                    f"Cannot compose {type(context).__name__}: it customises hooked-module spawning, "
+                    "which is not a shared-context capability."
+                )
 
     def _prepare_module(
         self,
@@ -290,9 +306,24 @@ class CompositeHookingContextFactory(HookingContextFactory):
         out_keys: List[UnraveledKey],
         extra_relative_path: str,
     ) -> TensorDictModuleBase:
-        for context in self._contexts:
-            module = context._prepare_module(module, in_keys, out_keys, extra_relative_path)
-        return module
+        prepared_contexts = []
+        original_module = module
+        try:
+            for context in self._contexts:
+                module = context._prepare_module(module, in_keys, out_keys, extra_relative_path)
+                prepared_contexts.append(context)
+            return module
+        except BaseException:
+            # A child can mutate the original module before raising.  Restore
+            # the failing child as well as every successfully prepared child
+            # in reverse order, just as on a normal context exit. Preserve the
+            # original exception.
+            for context in reversed([context, *prepared_contexts]):
+                try:
+                    context._restore_module(original_module, in_keys, out_keys, extra_relative_path)
+                except BaseException:
+                    pass
+            raise
 
     def _restore_module(
         self,
@@ -306,5 +337,36 @@ class CompositeHookingContextFactory(HookingContextFactory):
         return module
 
     def _hook_module(self, module: HookedModule) -> MultiHookHandle:
-        handles = [context._hook_module(module) for context in self._contexts]
-        return MultiHookHandle(handles)
+        handles = []
+        try:
+            for context in self._contexts:
+                handles.append(context._hook_module(self._child_module(module)))
+            return MultiHookHandle(handles)
+        except BaseException:
+            # Hooks registered by earlier children are live immediately.  Do
+            # not leave them installed when a later child cannot be installed.
+            MultiHookHandle(handles).remove()
+            raise
+
+    @staticmethod
+    def _child_module(module: HookedModule) -> HookedModule:
+        """Give a child a view whose relative root is the original module.
+
+        Preparation often wraps the input in a ``TensorDictSequential``.  The
+        original TensorDict module remains an object inside that final wrapper;
+        locating it by identity means every child's paths continue to resolve
+        as they did before composition, independent of the order of rewrites.
+        """
+        original = module.hooking_context._module
+        for name, candidate in module.td_module.named_modules(remove_duplicate=False):
+            if candidate is original:
+                relative_path = merge_paths("td_module", name, module.hooking_context._extra_relative_path)
+                return HookedModule(
+                    module.td_module, hooking_context=module.hooking_context, relative_path=relative_path
+                )
+        raise RuntimeError("Cannot compose hooks: the prepared module no longer contains the original module")
+
+
+# A clearer public name for the same-run composition API.  Keep the original
+# name for backwards compatibility.
+HookGroup = CompositeHookingContextFactory

--- a/src/tdhook/hooks.py
+++ b/src/tdhook/hooks.py
@@ -164,8 +164,14 @@ class MultiHookHandle:
         self._handles = handles or []
 
     def remove(self):
+        error = None
         for handle in self._handles:
-            handle.remove()
+            try:
+                handle.remove()
+            except Exception as exc:
+                error = error or exc
+        if error is not None:
+            raise error
 
     def __enter__(self):
         return self

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -9,10 +9,12 @@ from typing import List
 
 import pytest
 
-from tdhook.contexts import HookingContextFactory, CompositeHookingContextFactory
+from tdhook.contexts import HookingContextFactory, CompositeHookingContextFactory, HookGroup
 from tdhook.modules import HookedModule
 from tdhook.hooks import MultiHookHandle
 from tdhook._types import UnraveledKey
+from tdhook.attribution import Saliency
+from tdhook.latent import SteeringVectors
 
 
 class Context1(HookingContextFactory):
@@ -64,6 +66,17 @@ class BadSpawnFactory(HookingContextFactory):
         return super()._spawn_hooked_module(prep_module, hooking_context, extra_relative_path)
 
 
+class FailingPrepFactory(PrepFlagFactory):
+    def _prepare_module(self, module, in_keys, out_keys, extra_relative_path):
+        super()._prepare_module(module, in_keys, out_keys, extra_relative_path)
+        raise RuntimeError("preparation failed")
+
+
+class FailingHookFactory(HookingContextFactory):
+    def _hook_module(self, module):
+        raise RuntimeError("hook installation failed")
+
+
 class TestBaseContext:
     """Basic single-context behavior."""
 
@@ -101,6 +114,9 @@ class TestCompositeContext:
             hooked_module(data)
             assert data["output"].shape == (2, 3, 5)
             assert torch.allclose(data["output"], (original_output + 1) * 2)
+
+    def test_hook_group_is_compatibility_alias(self):
+        assert HookGroup is CompositeHookingContextFactory
 
 
 class TestHookingContextLifecycle:
@@ -234,8 +250,38 @@ class TestCompositeTensorDictModule:
 
     def test_composite_raises_on_bad_spawn_override(self, default_test_model):
         """Composite rejects contexts overriding _spawn_hooked_module."""
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="customises hooked-module spawning"):
             CompositeHookingContextFactory(BadSpawnFactory())
+
+    def test_composite_preparation_failure_restores_earlier_children(self, default_test_model):
+        td_mod = TensorDictModule(module=default_test_model, in_keys=["input"], out_keys=["output"])
+        composite = CompositeHookingContextFactory(PrepFlagFactory("first"), FailingPrepFactory("second"))
+        with pytest.raises(RuntimeError, match="preparation failed"):
+            with composite.prepare(td_mod):
+                pass
+        assert not hasattr(td_mod, "first")
+        assert not hasattr(td_mod, "second")
+
+    def test_composite_hook_failure_removes_registered_hooks(self, default_test_model):
+        composite = CompositeHookingContextFactory(Context1(), FailingHookFactory())
+        x = torch.randn(2, 3, 10)
+        original = default_test_model(x)
+        with pytest.raises(RuntimeError, match="hook installation failed"):
+            with composite.prepare(default_test_model):
+                pass
+        assert torch.allclose(default_test_model(x), original)
+
+    def test_saliency_and_steering_share_original_module_paths(self, default_test_model):
+        x = torch.randn(2, 3, 10)
+        composite = CompositeHookingContextFactory(
+            Saliency(),
+            SteeringVectors([""], lambda module_key, output: output + 1),
+        )
+        with composite.prepare(default_test_model) as hooked_module:
+            data = TensorDict({"input": x}, batch_size=[2, 3])
+            hooked_module(data)
+        assert data["_mod_out", "output"].shape == (2, 3, 5)
+        assert data["attr", "input"].shape == x.shape
 
 
 class TestDirectHookedModuleUsage:

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -19,7 +19,7 @@ from tdhook.modules import HookedModule
 from tdhook.hooks import MultiHookHandle
 from tdhook._types import UnraveledKey
 from tdhook.attribution import Saliency
-from tdhook.latent import SteeringVectors
+from tdhook.latent import SteeringVectors, ActivationPatching
 
 
 class Context1(HookingContextFactory):
@@ -102,6 +102,44 @@ class RestoreFailureFactory(HookingContextFactory):
 class ReplacementFactory(HookingContextFactory):
     def _prepare_module(self, module, in_keys, out_keys, extra_relative_path):
         return TensorDictModule(torch.nn.Identity(), in_keys=in_keys, out_keys=out_keys)
+
+
+class OrderedFailingFactory(PrepFlagFactory):
+    def __init__(self, name, events, fail=False):
+        super().__init__(name)
+        self.events = events
+        self.fail = fail
+
+    def _prepare_module(self, module, in_keys, out_keys, extra_relative_path):
+        self.events.append(f"prepare {self.flag_name}")
+        super()._prepare_module(module, in_keys, out_keys, extra_relative_path)
+        if self.fail:
+            raise RuntimeError("preparation failed")
+        return module
+
+    def _restore_module(self, module, in_keys, out_keys, extra_relative_path):
+        self.events.append(f"restore {self.flag_name}")
+        return super()._restore_module(module, in_keys, out_keys, extra_relative_path)
+
+
+class RemoveFailureHandle:
+    def __init__(self, should_fail, removed):
+        self.should_fail = should_fail
+        self.removed = removed
+
+    def remove(self):
+        self.removed.append(self.should_fail)
+        if self.should_fail:
+            raise RuntimeError("removal failed")
+
+
+class PartialRemovalFactory(HookingContextFactory):
+    def __init__(self, removed):
+        super().__init__()
+        self.removed = removed
+
+    def _hook_module(self, module):
+        return MultiHookHandle([RemoveFailureHandle(True, self.removed), RemoveFailureHandle(False, self.removed)])
 
 
 class TestBaseContext:
@@ -303,6 +341,16 @@ class TestCompositeTensorDictModule:
             with composite.prepare(default_test_model):
                 pass
 
+    def test_composite_restores_failed_preparation_in_lifo_order(self, default_test_model):
+        events = []
+        composite = CompositeHookingContextFactory(
+            OrderedFailingFactory("first", events), OrderedFailingFactory("second", events, fail=True)
+        )
+        with pytest.raises(RuntimeError, match="preparation failed"):
+            with composite.prepare(default_test_model):
+                pass
+        assert events == ["prepare first", "prepare second", "restore second", "restore first"]
+
     def test_composite_hook_failure_removes_registered_hooks(self, default_test_model):
         composite = CompositeHookingContextFactory(Context1(), FailingHookFactory())
         x = torch.randn(2, 3, 10)
@@ -311,6 +359,14 @@ class TestCompositeTensorDictModule:
             with composite.prepare(default_test_model):
                 pass
         assert torch.allclose(default_test_model(x), original)
+
+    def test_composite_hook_failure_attempts_every_registered_removal(self, default_test_model):
+        removed = []
+        composite = CompositeHookingContextFactory(PartialRemovalFactory(removed), FailingHookFactory())
+        with pytest.raises(RuntimeError, match="hook installation failed"):
+            with composite.prepare(default_test_model):
+                pass
+        assert removed == [True, False]
 
     def test_saliency_and_steering_share_original_module_paths(self, default_test_model):
         x = torch.randn(2, 3, 10)
@@ -323,6 +379,14 @@ class TestCompositeTensorDictModule:
             hooked_module(data)
         assert data["_mod_out", "output"].shape == (2, 3, 5)
         assert data["attr", "input"].shape == x.shape
+
+    def test_wrapped_children_keep_their_own_wrapper_state(self, default_test_model):
+        composite = CompositeHookingContextFactory(Saliency(), ActivationPatching([""]))
+        # Both children access a cache stored on their own TensorDict wrapper
+        # during hook installation. Context entry used to fail before a run
+        # because Saliency received ActivationPatching's wrapper instead.
+        with composite.prepare(default_test_model):
+            pass
 
     def test_composite_rejects_rewrites_that_drop_the_original_module(self, default_test_model):
         composite = CompositeHookingContextFactory(ReplacementFactory(), Context1())

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -9,7 +9,12 @@ from typing import List
 
 import pytest
 
-from tdhook.contexts import HookingContextFactory, CompositeHookingContextFactory, HookGroup
+from tdhook.contexts import (
+    HookingContextFactory,
+    HookingContextWithCache,
+    CompositeHookingContextFactory,
+    HookGroup,
+)
 from tdhook.modules import HookedModule
 from tdhook.hooks import MultiHookHandle
 from tdhook._types import UnraveledKey
@@ -75,6 +80,28 @@ class FailingPrepFactory(PrepFlagFactory):
 class FailingHookFactory(HookingContextFactory):
     def _hook_module(self, module):
         raise RuntimeError("hook installation failed")
+
+
+class SpecialisedContextFactory(HookingContextFactory):
+    _hooking_context_class = HookingContextWithCache
+
+
+class SpecialisedHookedModule(HookedModule):
+    pass
+
+
+class SpecialisedModuleFactory(HookingContextFactory):
+    _hooked_module_class = SpecialisedHookedModule
+
+
+class RestoreFailureFactory(HookingContextFactory):
+    def _restore_module(self, module, in_keys, out_keys, extra_relative_path):
+        raise RuntimeError("restoration failed")
+
+
+class ReplacementFactory(HookingContextFactory):
+    def _prepare_module(self, module, in_keys, out_keys, extra_relative_path):
+        return TensorDictModule(torch.nn.Identity(), in_keys=in_keys, out_keys=out_keys)
 
 
 class TestBaseContext:
@@ -253,6 +280,14 @@ class TestCompositeTensorDictModule:
         with pytest.raises(ValueError, match="customises hooked-module spawning"):
             CompositeHookingContextFactory(BadSpawnFactory())
 
+    def test_composite_rejects_specialised_context_capability(self):
+        with pytest.raises(ValueError, match="HookingContextWithCache capability"):
+            CompositeHookingContextFactory(SpecialisedContextFactory())
+
+    def test_composite_rejects_specialised_module_capability(self):
+        with pytest.raises(ValueError, match="SpecialisedHookedModule capability"):
+            CompositeHookingContextFactory(SpecialisedModuleFactory())
+
     def test_composite_preparation_failure_restores_earlier_children(self, default_test_model):
         td_mod = TensorDictModule(module=default_test_model, in_keys=["input"], out_keys=["output"])
         composite = CompositeHookingContextFactory(PrepFlagFactory("first"), FailingPrepFactory("second"))
@@ -261,6 +296,12 @@ class TestCompositeTensorDictModule:
                 pass
         assert not hasattr(td_mod, "first")
         assert not hasattr(td_mod, "second")
+
+    def test_composite_preserves_prepare_error_when_rollback_fails(self, default_test_model):
+        composite = CompositeHookingContextFactory(RestoreFailureFactory(), FailingPrepFactory())
+        with pytest.raises(RuntimeError, match="preparation failed"):
+            with composite.prepare(default_test_model):
+                pass
 
     def test_composite_hook_failure_removes_registered_hooks(self, default_test_model):
         composite = CompositeHookingContextFactory(Context1(), FailingHookFactory())
@@ -282,6 +323,12 @@ class TestCompositeTensorDictModule:
             hooked_module(data)
         assert data["_mod_out", "output"].shape == (2, 3, 5)
         assert data["attr", "input"].shape == x.shape
+
+    def test_composite_rejects_rewrites_that_drop_the_original_module(self, default_test_model):
+        composite = CompositeHookingContextFactory(ReplacementFactory(), Context1())
+        with pytest.raises(RuntimeError, match="no longer contains the original module"):
+            with composite.prepare(default_test_model):
+                pass
 
 
 class TestDirectHookedModuleUsage:


### PR DESCRIPTION
## Summary

- rebase each child hook factory onto the original module after ordered wrapper rewrites
- make preparation and hook installation transactional, with rollback on failure
- add capability-based diagnostics for unsupported specialised contexts and the `HookGroup` compatibility alias
- document ordering and the supported same-run composition boundary

## Validation

- `uv run pytest tests -q` (420 passed)
- pre-commit hooks: ruff check and ruff format passed

Closes #59.