### PR TITLE
Standardize artifact schemas, ownership, and provenance

### DIFF
--- a/docs/source/artifacts.rst
+++ b/docs/source/artifacts.rst
@@ -1,0 +1,26 @@
+Artifact contracts and provenance
+=================================
+
+Pipeline artifacts have a stable public schema. Public keys start with one of
+``inputs``, ``outputs``, ``activations``, ``gradients``, ``attributions``,
+``probes``, ``interventions``, or ``metrics``. Temporary implementation values
+are private and must be placed below ``("_private", method, ...)``. Private
+keys are owned by the creating context or manager and must be cleared when that
+owner exits; they are never a supported downstream dependency.
+
+Stages can declare an :class:`tdhook.artifacts.ArtifactContract`, which gives
+each requirement and product a method-facing name and a public TensorDict key.
+An :class:`tdhook.artifacts.ArtifactAdapter` maps this contract onto existing
+method storage without changing that method's standalone return behaviour.
+The built-in adapter helpers cover activation caching, probing, attribution,
+and weight adapters.
+
+``Pipeline.run`` returns provenance alongside artifacts and stage metadata.
+Pass the caller's stable ``model_id``, an optional ``seed``, and per-stage
+configuration to record model identity, device/dtype, package version, parent
+artifact keys, and method configuration. This is in-memory metadata only:
+serialization remains the responsibility of the caller.
+
+``ArtifactRegistry`` can be used by a host that keeps artifacts across runs.
+It assigns ownership by generation and rejects a key from an earlier generation
+when it is required as fresh, preventing stale cache reuse.

--- a/docs/source/artifacts.rst
+++ b/docs/source/artifacts.rst
@@ -12,8 +12,12 @@ Stages can declare an :class:`tdhook.artifacts.ArtifactContract`, which gives
 each requirement and product a method-facing name and a public TensorDict key.
 An :class:`tdhook.artifacts.ArtifactAdapter` maps this contract onto existing
 method storage without changing that method's standalone return behaviour.
-The built-in adapter helpers cover activation caching, probing, attribution,
-and weight adapters.
+Use :class:`tdhook.pipeline.AdapterStage` to copy declared public requirements
+into that storage before execution and publish declared products afterwards.
+Its ``execute`` callback receives ``(model, artifacts, storage)``; pass the
+provided storage as the legacy method's cache or result TensorDict. The built-in
+adapter helpers cover activation caching, probing, attribution, and weight
+adapters.
 
 ``Pipeline.run`` returns provenance alongside artifacts and stage metadata.
 Pass the caller's stable ``model_id``, an optional ``seed``, and per-stage

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@
     start
     methods
     composition
+    artifacts
     tutorials
     api/index
     references

--- a/src/tdhook/__init__.py
+++ b/src/tdhook/__init__.py
@@ -17,4 +17,5 @@ __all__ = [
     "auto",
     "weights",
     "pipeline",
+    "artifacts",
 ]

--- a/src/tdhook/artifacts.py
+++ b/src/tdhook/artifacts.py
@@ -13,6 +13,7 @@ from importlib.metadata import PackageNotFoundError, version
 from typing import Iterable, Mapping
 
 from torch import nn
+from tensordict import TensorDict, TensorDictBase
 
 from tdhook._types import UnraveledKey
 
@@ -102,8 +103,10 @@ class ArtifactAdapter:
     """Map a public contract onto the keys used by an existing method.
 
     ``storage`` maps each contract name to the method's current TensorDict
-    key.  It is intentionally metadata-only: adopting it never changes a
-    standalone method's return value or cache ownership.
+    key. :meth:`prepare` copies public requirements into that legacy storage;
+    :meth:`finalize` copies declared products back to the public contract.
+    These methods provide the runtime bridge used by ``AdapterStage`` while
+    leaving standalone methods unchanged.
     """
 
     method: str
@@ -118,6 +121,23 @@ class ArtifactAdapter:
             raise ValueError("Adapter storage keys must exactly match its contract names")
         for key in self.storage.values():
             _path(key)
+
+    def prepare(self, artifacts: TensorDictBase, storage: TensorDictBase | None = None) -> TensorDictBase:
+        """Populate legacy storage with this adapter's public requirements."""
+        storage = TensorDict() if storage is None else storage
+        for name, public_key in self.contract.requires.items():
+            storage.set(self.storage[name], artifacts.get(public_key))
+        return storage
+
+    def finalize(self, artifacts: TensorDictBase, storage: TensorDictBase) -> TensorDictBase:
+        """Publish declared legacy products under their stable public keys."""
+        for name, public_key in self.contract.provides.items():
+            legacy_key = self.storage[name]
+            if legacy_key not in storage.keys(include_nested=True, leaves_only=True):
+                raise ValueError(f"Legacy method {self.method!r} did not provide {legacy_key!r}")
+            value = storage.get(legacy_key)
+            artifacts.set(public_key, value)
+        return artifacts
 
 
 def activation_caching_adapter(cache_key: ArtifactKey = "cache") -> ArtifactAdapter:

--- a/src/tdhook/artifacts.py
+++ b/src/tdhook/artifacts.py
@@ -1,0 +1,228 @@
+"""Stable, migration-friendly contracts for pipeline artifacts.
+
+This module deliberately describes *what* a method exchanges separately from
+the TensorDict key where a current implementation stores it.  New pipeline
+code should use the public namespaces below; adapters keep legacy methods
+usable while their internals are migrated incrementally.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from importlib.metadata import PackageNotFoundError, version
+from typing import Iterable, Mapping
+
+from torch import nn
+
+from tdhook._types import UnraveledKey
+
+
+ArtifactKey = UnraveledKey
+PUBLIC_NAMESPACES = frozenset(
+    {
+        "inputs",
+        "outputs",
+        "activations",
+        "gradients",
+        "attributions",
+        "probes",
+        "interventions",
+        "metrics",
+    }
+)
+PRIVATE_NAMESPACE = "_private"
+
+
+def _path(key: ArtifactKey) -> tuple[str, ...]:
+    if isinstance(key, str):
+        return (key,)
+    if not isinstance(key, tuple) or not key or not all(isinstance(part, str) and part for part in key):
+        raise TypeError(f"Artifact keys must be strings or non-empty tuples of strings, got {key!r}")
+    return key
+
+
+def is_private_key(key: ArtifactKey) -> bool:
+    """Return whether *key* is owned by a method implementation."""
+    return _path(key)[0] == PRIVATE_NAMESPACE
+
+
+def validate_artifact_key(key: ArtifactKey, *, public: bool = True) -> ArtifactKey:
+    """Validate a stable public key, or a private implementation key.
+
+    Public artifacts always start with a documented namespace.  Private
+    values must be nested below ``("_private", method, ...)`` so that they
+    cannot accidentally become a cross-stage dependency.
+    """
+    path = _path(key)
+    if public and path[0] not in PUBLIC_NAMESPACES:
+        raise ValueError(f"Public artifact key {key!r} must start with one of {sorted(PUBLIC_NAMESPACES)!r}")
+    if not public and (path[0] != PRIVATE_NAMESPACE or len(path) < 2):
+        raise ValueError("Private artifact keys must be nested below ('_private', <method>, ...)")
+    return key
+
+
+def _named_keys(keys: Mapping[str, ArtifactKey], *, role: str) -> dict[str, ArtifactKey]:
+    result = dict(keys)
+    if any(not isinstance(name, str) or not name for name in result):
+        raise ValueError(f"{role} artifact names must be non-empty strings")
+    for key in result.values():
+        validate_artifact_key(key)
+    if len(set(result.values())) != len(result):
+        raise ValueError(f"{role} artifact keys must be unique")
+    return result
+
+
+@dataclass(frozen=True)
+class ArtifactContract:
+    """Named public requirements and products of one pipeline stage.
+
+    Names are method-facing (for example ``"source"`` or ``"scores"``),
+    while keys are storage-facing.  This lets a stage depend on a contract
+    without exposing a legacy cache layout as its API.
+    """
+
+    requires: Mapping[str, ArtifactKey] = field(default_factory=dict)
+    provides: Mapping[str, ArtifactKey] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "requires", _named_keys(self.requires, role="Required"))
+        object.__setattr__(self, "provides", _named_keys(self.provides, role="Provided"))
+
+    @property
+    def required_keys(self) -> tuple[ArtifactKey, ...]:
+        return tuple(self.requires.values())
+
+    @property
+    def provided_keys(self) -> tuple[ArtifactKey, ...]:
+        return tuple(self.provides.values())
+
+
+@dataclass(frozen=True)
+class ArtifactAdapter:
+    """Map a public contract onto the keys used by an existing method.
+
+    ``storage`` maps each contract name to the method's current TensorDict
+    key.  It is intentionally metadata-only: adopting it never changes a
+    standalone method's return value or cache ownership.
+    """
+
+    method: str
+    contract: ArtifactContract
+    storage: Mapping[str, ArtifactKey]
+
+    def __post_init__(self) -> None:
+        names = set(self.contract.requires) | set(self.contract.provides)
+        if not self.method:
+            raise ValueError("An artifact adapter needs a method identifier")
+        if set(self.storage) != names:
+            raise ValueError("Adapter storage keys must exactly match its contract names")
+        for key in self.storage.values():
+            _path(key)
+
+
+def activation_caching_adapter(cache_key: ArtifactKey = "cache") -> ArtifactAdapter:
+    return ArtifactAdapter(
+        "activation-caching",
+        ArtifactContract(provides={"activations": ("activations", "cache")}),
+        {"activations": cache_key},
+    )
+
+
+def probing_adapter(result_key: ArtifactKey = "probes") -> ArtifactAdapter:
+    return ArtifactAdapter(
+        "probing", ArtifactContract(provides={"results": ("probes", "results")}), {"results": result_key}
+    )
+
+
+def attribution_adapter(result_key: ArtifactKey = "attr") -> ArtifactAdapter:
+    return ArtifactAdapter(
+        "attribution",
+        ArtifactContract(provides={"attributions": ("attributions", "values")}),
+        {"attributions": result_key},
+    )
+
+
+def weight_adapter(cache_key: ArtifactKey = "cache") -> ArtifactAdapter:
+    """Adapter contract for the existing :class:`tdhook.weights.Adapters` method."""
+    return ArtifactAdapter(
+        "weight-adapters",
+        ArtifactContract(provides={"interventions": ("interventions", "weights")}),
+        {"interventions": cache_key},
+    )
+
+
+@dataclass(frozen=True)
+class ArtifactProvenance:
+    """Lightweight, in-memory provenance returned with :class:`PipelineResult`."""
+
+    stage: str
+    method: str
+    configuration: Mapping[str, object]
+    package_version: str
+    model_id: str | None
+    device: str | None
+    dtype: str | None
+    seed: int | None
+    parents: tuple[ArtifactKey, ...] = ()
+
+
+def make_provenance(
+    *,
+    stage: str,
+    method: str,
+    configuration: Mapping[str, object] | None = None,
+    model_id: str | None = None,
+    seed: int | None = None,
+    parents: Iterable[ArtifactKey] = (),
+    model: nn.Module | None = None,
+) -> ArtifactProvenance:
+    """Build serialisation-safe metadata without retaining a model reference."""
+    try:
+        package_version = version("tdhook")
+    except PackageNotFoundError:
+        package_version = "unknown"
+    tensor = None
+    if model is not None:
+        tensor = next(iter(model.parameters()), None)
+        if tensor is None:
+            tensor = next(iter(model.buffers()), None)
+    return ArtifactProvenance(
+        stage=stage,
+        method=method,
+        configuration=dict(configuration or {}),
+        package_version=package_version,
+        model_id=model_id,
+        device=None if tensor is None else str(tensor.device),
+        dtype=None if tensor is None else str(tensor.dtype),
+        seed=seed,
+        parents=tuple(parents),
+    )
+
+
+class ArtifactRegistry:
+    """Track ownership within one artifact exchange and reject stale reuse."""
+
+    def __init__(self) -> None:
+        self._generation = 0
+        self._records: dict[ArtifactKey, tuple[str, int]] = {}
+
+    def begin_generation(self) -> int:
+        self._generation += 1
+        return self._generation
+
+    def claim(self, key: ArtifactKey, owner: str, *, generation: int | None = None) -> None:
+        generation = self._generation if generation is None else generation
+        existing = self._records.get(key)
+        if existing is not None and existing[0] != owner:
+            raise ValueError(f"Artifact key {key!r} is already owned by {existing[0]!r}")
+        self._records[key] = (owner, generation)
+
+    def require_fresh(self, key: ArtifactKey, *, generation: int | None = None) -> None:
+        generation = self._generation if generation is None else generation
+        if key not in self._records:
+            raise ValueError(f"Artifact key {key!r} has not been registered")
+        owner, recorded_generation = self._records[key]
+        if recorded_generation != generation:
+            raise ValueError(
+                f"Artifact key {key!r} from {owner!r} is stale (generation {recorded_generation}, expected {generation})"
+            )

--- a/src/tdhook/pipeline.py
+++ b/src/tdhook/pipeline.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Callable, Iterable, Sequence
+from typing import Callable, Iterable, Mapping, Sequence
 
 from torch import nn
 from tensordict import TensorDictBase
 
 from tdhook._types import UnraveledKey
+from tdhook.artifacts import ArtifactContract, ArtifactProvenance, make_provenance
 from tdhook.contexts import HookingContextFactory
 
 
@@ -58,6 +59,7 @@ class PipelineResult:
 
     artifacts: TensorDictBase
     stages: tuple[StageResult, ...]
+    provenance: tuple[ArtifactProvenance, ...] = ()
 
 
 class Stage(ABC):
@@ -71,12 +73,16 @@ class Stage(ABC):
         provided_keys: Iterable[PipelineKey] = (),
         effects: Iterable[str] = (),
         incompatible_effects: Iterable[str] = (),
+        artifact_contract: ArtifactContract | None = None,
     ) -> None:
         if not name:
             raise ValueError("A stage must have a non-empty name")
         self.name = name
-        self.required_keys = _keys(required_keys)
-        self.provided_keys = _keys(provided_keys)
+        if artifact_contract is not None and (tuple(required_keys) or tuple(provided_keys)):
+            raise ValueError("Use either artifact_contract or storage keys, not both")
+        self.artifact_contract = artifact_contract
+        self.required_keys = _keys(artifact_contract.required_keys if artifact_contract else required_keys)
+        self.provided_keys = _keys(artifact_contract.provided_keys if artifact_contract else provided_keys)
         self.effects = frozenset(effects)
         self.incompatible_effects = frozenset(incompatible_effects)
 
@@ -93,12 +99,13 @@ class MethodStage(Stage):
         name: str,
         factory: HookingContextFactory,
         *,
-        required_keys: Iterable[PipelineKey],
-        provided_keys: Iterable[PipelineKey],
+        required_keys: Iterable[PipelineKey] = (),
+        provided_keys: Iterable[PipelineKey] = (),
         effects: Iterable[str] = (),
         incompatible_effects: Iterable[str] = (),
         model_in_keys: Iterable[PipelineKey] | None = None,
         model_out_keys: Iterable[PipelineKey] | None = None,
+        artifact_contract: ArtifactContract | None = None,
     ) -> None:
         super().__init__(
             name,
@@ -106,6 +113,7 @@ class MethodStage(Stage):
             provided_keys=provided_keys,
             effects=("model_execution", *effects),
             incompatible_effects=incompatible_effects,
+            artifact_contract=artifact_contract,
         )
         self.factory = factory
         self.model_in_keys = None if model_in_keys is None else _keys(model_in_keys)
@@ -133,6 +141,7 @@ class TransformStage(Stage):
         provided_keys: Iterable[PipelineKey] = (),
         effects: Iterable[str] = (),
         incompatible_effects: Iterable[str] = (),
+        artifact_contract: ArtifactContract | None = None,
     ) -> None:
         super().__init__(
             name,
@@ -140,6 +149,7 @@ class TransformStage(Stage):
             provided_keys=provided_keys,
             effects=effects,
             incompatible_effects=incompatible_effects,
+            artifact_contract=artifact_contract,
         )
         self.transform = transform
 
@@ -212,9 +222,18 @@ class Pipeline:
                 raise ValueError(f"Stage {stage.name!r} writes existing artifact keys: {collisions!r}")
             available.update(stage.provided_keys)
 
-    def run(self, model: nn.Module, artifacts: TensorDictBase) -> PipelineResult:
+    def run(
+        self,
+        model: nn.Module,
+        artifacts: TensorDictBase,
+        *,
+        model_id: str | None = None,
+        seed: int | None = None,
+        stage_configurations: Mapping[str, Mapping[str, object]] | None = None,
+    ) -> PipelineResult:
         self.validate(artifacts)
         stage_results: list[StageResult] = []
+        provenance: list[ArtifactProvenance] = []
         current = artifacts
         for stage in self.stages:
             missing = [key for key in stage.required_keys if key not in self._artifact_keys(current)]
@@ -230,4 +249,15 @@ class Pipeline:
             if missing:
                 raise ValueError(f"Stage {stage.name!r} did not provide declared artifact keys: {missing!r}")
             stage_results.append(StageResult(stage.name, stage.provided_keys, stage.effects))
-        return PipelineResult(current, tuple(stage_results))
+            provenance.append(
+                make_provenance(
+                    stage=stage.name,
+                    method=type(stage).__name__,
+                    configuration=(stage_configurations or {}).get(stage.name),
+                    model_id=model_id,
+                    seed=seed,
+                    parents=stage.required_keys,
+                    model=model,
+                )
+            )
+        return PipelineResult(current, tuple(stage_results), tuple(provenance))

--- a/src/tdhook/pipeline.py
+++ b/src/tdhook/pipeline.py
@@ -16,7 +16,7 @@ from torch import nn
 from tensordict import TensorDictBase
 
 from tdhook._types import UnraveledKey
-from tdhook.artifacts import ArtifactContract, ArtifactProvenance, make_provenance
+from tdhook.artifacts import ArtifactAdapter, ArtifactContract, ArtifactProvenance, make_provenance
 from tdhook.contexts import HookingContextFactory
 
 
@@ -74,6 +74,7 @@ class Stage(ABC):
         effects: Iterable[str] = (),
         incompatible_effects: Iterable[str] = (),
         artifact_contract: ArtifactContract | None = None,
+        method_id: str | None = None,
     ) -> None:
         if not name:
             raise ValueError("A stage must have a non-empty name")
@@ -81,6 +82,9 @@ class Stage(ABC):
         if artifact_contract is not None and (tuple(required_keys) or tuple(provided_keys)):
             raise ValueError("Use either artifact_contract or storage keys, not both")
         self.artifact_contract = artifact_contract
+        self.method_id = type(self).__name__ if method_id is None else method_id
+        if not self.method_id:
+            raise ValueError("A stage method identifier must be non-empty")
         self.required_keys = _keys(artifact_contract.required_keys if artifact_contract else required_keys)
         self.provided_keys = _keys(artifact_contract.provided_keys if artifact_contract else provided_keys)
         self.effects = frozenset(effects)
@@ -106,6 +110,7 @@ class MethodStage(Stage):
         model_in_keys: Iterable[PipelineKey] | None = None,
         model_out_keys: Iterable[PipelineKey] | None = None,
         artifact_contract: ArtifactContract | None = None,
+        method_id: str | None = None,
     ) -> None:
         super().__init__(
             name,
@@ -114,6 +119,7 @@ class MethodStage(Stage):
             effects=("model_execution", *effects),
             incompatible_effects=incompatible_effects,
             artifact_contract=artifact_contract,
+            method_id=type(factory).__name__ if method_id is None else method_id,
         )
         self.factory = factory
         self.model_in_keys = None if model_in_keys is None else _keys(model_in_keys)
@@ -142,6 +148,7 @@ class TransformStage(Stage):
         effects: Iterable[str] = (),
         incompatible_effects: Iterable[str] = (),
         artifact_contract: ArtifactContract | None = None,
+        method_id: str | None = None,
     ) -> None:
         super().__init__(
             name,
@@ -150,6 +157,7 @@ class TransformStage(Stage):
             effects=effects,
             incompatible_effects=incompatible_effects,
             artifact_contract=artifact_contract,
+            method_id=_callable_identity(transform) if method_id is None else method_id,
         )
         self.transform = transform
 
@@ -158,6 +166,46 @@ class TransformStage(Stage):
         if not isinstance(result, TensorDictBase):
             raise TypeError(f"Transform stage {self.name!r} must return a TensorDict, got {type(result).__name__}")
         return result
+
+
+def _callable_identity(transform: Callable[..., object]) -> str:
+    """Return a useful identifier for provenance."""
+    module = getattr(transform, "__module__", type(transform).__module__)
+    name = getattr(transform, "__qualname__", type(transform).__qualname__)
+    return f"{module}.{name}"
+
+
+class AdapterStage(Stage):
+    """Run a legacy method against adapter-managed storage.
+
+    ``execute`` receives the model, public artifacts, and a TensorDict using
+    the legacy method's keys. It may return replacement public artifacts or
+    ``None`` after mutating them in place.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        adapter: ArtifactAdapter,
+        execute: Callable[[nn.Module, TensorDictBase, TensorDictBase], TensorDictBase | None],
+        *,
+        effects: Iterable[str] = (),
+        incompatible_effects: Iterable[str] = (),
+    ) -> None:
+        super().__init__(
+            name,
+            artifact_contract=adapter.contract,
+            effects=effects,
+            incompatible_effects=incompatible_effects,
+            method_id=adapter.method,
+        )
+        self.adapter = adapter
+        self.execute = execute
+
+    def run(self, model: nn.Module, artifacts: TensorDictBase) -> TensorDictBase:
+        storage = self.adapter.prepare(artifacts)
+        result = self.execute(model, artifacts, storage)
+        return self.adapter.finalize(artifacts if result is None else result, storage)
 
 
 class Pipeline:
@@ -252,7 +300,7 @@ class Pipeline:
             provenance.append(
                 make_provenance(
                     stage=stage.name,
-                    method=type(stage).__name__,
+                    method=stage.method_id,
                     configuration=(stage_configurations or {}).get(stage.name),
                     model_id=model_id,
                     seed=seed,

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,5 +1,8 @@
 import pytest
+import torch
+from torch import nn
 
+import tdhook.artifacts as artifacts
 from tdhook.artifacts import (
     ArtifactAdapter,
     ArtifactContract,
@@ -7,6 +10,8 @@ from tdhook.artifacts import (
     activation_caching_adapter,
     attribution_adapter,
     probing_adapter,
+    is_private_key,
+    make_provenance,
     validate_artifact_key,
     weight_adapter,
 )
@@ -23,6 +28,10 @@ def test_public_and_private_namespace_validation():
         validate_artifact_key("image")
     with pytest.raises(ValueError, match="Private artifact keys"):
         validate_artifact_key("scratch", public=False)
+    with pytest.raises(TypeError, match="Artifact keys"):
+        validate_artifact_key(("inputs", 1))
+    assert is_private_key(("_private", "saliency"))
+    assert not is_private_key(("inputs", "image"))
 
 
 def test_contracts_and_existing_method_adapters_are_storage_independent():
@@ -34,6 +43,32 @@ def test_contracts_and_existing_method_adapters_are_storage_independent():
     assert probing_adapter().contract.provided_keys == (("probes", "results"),)
     assert attribution_adapter().contract.provided_keys == (("attributions", "values"),)
     assert weight_adapter().contract.provided_keys == (("interventions", "weights"),)
+
+    with pytest.raises(ValueError, match="names must be non-empty"):
+        ArtifactContract(requires={"": ("inputs", "image")})
+    with pytest.raises(ValueError, match="keys must be unique"):
+        ArtifactContract(provides={"one": ("metrics", "score"), "two": ("metrics", "score")})
+    with pytest.raises(ValueError, match="method identifier"):
+        ArtifactAdapter("", contract, {"source": "image", "score": "score"})
+    with pytest.raises(ValueError, match="exactly match"):
+        ArtifactAdapter("legacy-score", contract, {"source": "image"})
+
+
+def test_provenance_handles_missing_package_metadata_and_buffer_only_models(monkeypatch):
+    class BufferOnlyModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.register_buffer("scale", torch.ones(1))
+
+    def missing_package(_):
+        raise artifacts.PackageNotFoundError
+
+    monkeypatch.setattr(artifacts, "version", missing_package)
+    provenance = make_provenance(stage="cache", method="ActivationCaching", model=BufferOnlyModel())
+
+    assert provenance.package_version == "unknown"
+    assert provenance.device == "cpu"
+    assert provenance.dtype == "torch.float32"
 
 
 def test_registry_rejects_conflicting_owners_and_stale_artifacts():

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,0 +1,50 @@
+import pytest
+
+from tdhook.artifacts import (
+    ArtifactAdapter,
+    ArtifactContract,
+    ArtifactRegistry,
+    activation_caching_adapter,
+    attribution_adapter,
+    probing_adapter,
+    validate_artifact_key,
+    weight_adapter,
+)
+
+
+def test_public_and_private_namespace_validation():
+    assert validate_artifact_key(("inputs", "image")) == ("inputs", "image")
+    assert validate_artifact_key(("_private", "saliency", "grads"), public=False) == (
+        "_private",
+        "saliency",
+        "grads",
+    )
+    with pytest.raises(ValueError, match="Public artifact key"):
+        validate_artifact_key("image")
+    with pytest.raises(ValueError, match="Private artifact keys"):
+        validate_artifact_key("scratch", public=False)
+
+
+def test_contracts_and_existing_method_adapters_are_storage_independent():
+    contract = ArtifactContract(requires={"source": ("inputs", "image")}, provides={"score": ("metrics", "score")})
+    adapter = ArtifactAdapter("legacy-score", contract, {"source": "image", "score": "score"})
+    assert adapter.contract.required_keys == (("inputs", "image"),)
+    assert adapter.storage["score"] == "score"
+    assert activation_caching_adapter().contract.provided_keys == (("activations", "cache"),)
+    assert probing_adapter().contract.provided_keys == (("probes", "results"),)
+    assert attribution_adapter().contract.provided_keys == (("attributions", "values"),)
+    assert weight_adapter().contract.provided_keys == (("interventions", "weights"),)
+
+
+def test_registry_rejects_conflicting_owners_and_stale_artifacts():
+    registry = ArtifactRegistry()
+    first = registry.begin_generation()
+    registry.claim(("activations", "layer"), "cache", generation=first)
+    registry.require_fresh(("activations", "layer"), generation=first)
+    second = registry.begin_generation()
+    with pytest.raises(ValueError, match="not been registered"):
+        registry.require_fresh(("activations", "missing"), generation=second)
+    with pytest.raises(ValueError, match="stale"):
+        registry.require_fresh(("activations", "layer"), generation=second)
+    with pytest.raises(ValueError, match="already owned"):
+        registry.claim(("activations", "layer"), "other", generation=second)

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 from torch import nn
+from tensordict import TensorDict
 
 import tdhook.artifacts as artifacts
 from tdhook.artifacts import (
@@ -52,6 +53,24 @@ def test_contracts_and_existing_method_adapters_are_storage_independent():
         ArtifactAdapter("", contract, {"source": "image", "score": "score"})
     with pytest.raises(ValueError, match="exactly match"):
         ArtifactAdapter("legacy-score", contract, {"source": "image"})
+
+
+def test_adapter_copies_public_requirements_and_products_through_legacy_storage():
+    adapter = ArtifactAdapter(
+        "legacy-score",
+        ArtifactContract(requires={"source": ("inputs", "image")}, provides={"score": ("metrics", "score")}),
+        {"source": "image", "score": "score"},
+    )
+    artifacts_td = TensorDict({"inputs": {"image": torch.ones(2)}}, batch_size=[2])
+    storage = adapter.prepare(artifacts_td)
+    assert torch.equal(storage["image"], artifacts_td[("inputs", "image")])
+
+    storage.set("score", torch.ones(2))
+    result = adapter.finalize(artifacts_td, storage)
+    assert torch.equal(result[("metrics", "score")], torch.ones(2))
+
+    with pytest.raises(ValueError, match="did not provide"):
+        adapter.finalize(artifacts_td, TensorDict())
 
 
 def test_provenance_handles_missing_package_metadata_and_buffer_only_models(monkeypatch):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -106,6 +106,13 @@ def test_public_artifact_contract_and_provenance(default_test_model):
     assert result.provenance[0].configuration == {"normalise": False}
 
 
+def test_artifact_contract_cannot_be_combined_with_legacy_storage_keys():
+    contract = ArtifactContract(provides={"prediction": ("outputs", "prediction")})
+
+    with pytest.raises(ValueError, match="either artifact_contract or storage keys"):
+        TransformStage("predict", lambda td: td, provided_keys=["prediction"], artifact_contract=contract)
+
+
 def test_invalid_dependencies_fail_before_model_execution(default_test_model):
     called = False
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -4,10 +4,10 @@ from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
 
 from tdhook.contexts import HookingContextFactory
-from tdhook.artifacts import ArtifactContract
+from tdhook.artifacts import ArtifactAdapter, ArtifactContract
 from tdhook.hooks import MultiHookHandle
 from tdhook.modules import HookedModule
-from tdhook.pipeline import MethodStage, Pipeline, Stage, TransformStage
+from tdhook.pipeline import AdapterStage, MethodStage, Pipeline, Stage, TransformStage
 
 
 class AddOne(HookingContextFactory):
@@ -100,6 +100,7 @@ def test_public_artifact_contract_and_provenance(default_test_model):
     )
 
     assert result.artifacts[("outputs", "prediction")].shape == (2, 10)
+    assert result.provenance[0].method.endswith(".<lambda>")
     assert result.provenance[0].model_id == "demo-model-v1"
     assert result.provenance[0].seed == 7
     assert result.provenance[0].parents == (("inputs", "model"),)
@@ -111,6 +112,32 @@ def test_artifact_contract_cannot_be_combined_with_legacy_storage_keys():
 
     with pytest.raises(ValueError, match="either artifact_contract or storage keys"):
         TransformStage("predict", lambda td: td, provided_keys=["prediction"], artifact_contract=contract)
+
+
+def test_adapter_stage_bridges_legacy_storage_and_records_concrete_method(default_test_model):
+    adapter = ArtifactAdapter(
+        "legacy-score",
+        ArtifactContract(requires={"source": ("inputs", "value")}, provides={"score": ("metrics", "score")}),
+        {"source": "value", "score": "score"},
+    )
+
+    def execute(model, artifacts, storage):
+        storage.set("score", storage["value"] + 1)
+
+    result = Pipeline([AdapterStage("score", adapter, execute)]).run(
+        default_test_model, TensorDict({"inputs": {"value": torch.ones(1)}}, batch_size=[1])
+    )
+
+    assert result.artifacts[("metrics", "score")].item() == 2
+    assert result.provenance[0].method == "legacy-score"
+
+
+def test_method_stage_records_factory_identity(default_test_model):
+    result = Pipeline([MethodStage("predict", AddOne(), required_keys=["input"], provided_keys=["output"])]).run(
+        default_test_model, TensorDict({"input": torch.ones(2, 10)}, batch_size=[2])
+    )
+
+    assert result.provenance[0].method == "AddOne"
 
 
 def test_invalid_dependencies_fail_before_model_execution(default_test_model):
@@ -153,6 +180,8 @@ def test_duplicate_outputs_and_reserved_keys_are_rejected():
 def test_stage_contract_validation_errors():
     with pytest.raises(ValueError, match="non-empty"):
         TransformStage("", lambda td: td)
+    with pytest.raises(ValueError, match="method identifier"):
+        TransformStage("missing-method", lambda td: td, method_id="")
     with pytest.raises(TypeError, match="Pipeline keys"):
         TransformStage("bad-key", lambda td: td, required_keys=[1])
     with pytest.raises(ValueError, match="duplicate keys"):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -4,6 +4,7 @@ from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
 
 from tdhook.contexts import HookingContextFactory
+from tdhook.artifacts import ArtifactContract
 from tdhook.hooks import MultiHookHandle
 from tdhook.modules import HookedModule
 from tdhook.pipeline import MethodStage, Pipeline, Stage, TransformStage
@@ -74,6 +75,35 @@ def test_method_stage_keeps_artifact_contract_separate_from_model_signature(defa
 
     assert "baseline" in result.artifacts
     assert torch.allclose(result.artifacts["prediction"], default_test_model(artifacts["model_input"]))
+
+
+def test_public_artifact_contract_and_provenance(default_test_model):
+    contract = ArtifactContract(
+        requires={"source": ("inputs", "model")}, provides={"prediction": ("outputs", "prediction")}
+    )
+    pipeline = Pipeline(
+        [
+            TransformStage(
+                "predict",
+                lambda td: td.set(("outputs", "prediction"), td[("inputs", "model")] + 1),
+                artifact_contract=contract,
+            )
+        ]
+    )
+
+    result = pipeline.run(
+        default_test_model,
+        TensorDict({"inputs": {"model": torch.ones(2, 10)}}, batch_size=[2]),
+        model_id="demo-model-v1",
+        seed=7,
+        stage_configurations={"predict": {"normalise": False}},
+    )
+
+    assert result.artifacts[("outputs", "prediction")].shape == (2, 10)
+    assert result.provenance[0].model_id == "demo-model-v1"
+    assert result.provenance[0].seed == 7
+    assert result.provenance[0].parents == (("inputs", "model"),)
+    assert result.provenance[0].configuration == {"normalise": False}
 
 
 def test_invalid_dependencies_fail_before_model_execution(default_test_model):


### PR DESCRIPTION
## Summary

- define public/private artifact namespaces and named stage contracts
- add migration-safe adapters for activation caching, probing, attribution, and weight adapters
- return per-stage provenance and provide generation-based stale artifact detection
- document ownership/serialization boundaries and cover the API with tests

## Validation

- `uv run pytest tests` (420 passed)
- `uv run pytest tests/test_artifacts.py tests/test_pipeline.py` (15 passed)

Closes #60.