### PR TITLE
Add executable pipeline stage adapters

### DIFF
--- a/docs/source/composition.rst
+++ b/docs/source/composition.rst
@@ -163,6 +163,23 @@ probing objects are included so the public surface is complete, but are marked
 ``probing support`` rather than executable stages.  Implementation helpers that
 are not exported by those modules are not stable public methods.
 
+Executable built-in stages
+--------------------------
+
+For the method families used by the ECML demonstrations, use the factories in
+``tdhook.stages`` rather than writing an ``AdapterStage`` callback. They run
+the existing public method unchanged and translate its legacy storage into
+stable artifact paths. For example, ``activation_caching_stage`` publishes the
+real context cache at ``("activations", "cache")``; it never labels that cache
+as weights. ``attribution_stage``, ``probing_stage``, and
+``weight_intervention_stage`` respectively publish attribution values, probe
+manager results, and an intervention pass's model output.
+
+Each factory has an executable ``StageCapability`` record. The composition
+contract tests check that the documented rows for ``ActivationCaching``,
+``Probing``, and ``Adapters`` still resolve to one of those records, so an API
+or matrix change cannot quietly drop its implementation contract.
+
 .. csv-table:: Public capability inventory
    :file: _static/composition-capabilities.csv
    :header-rows: 1

--- a/src/tdhook/__init__.py
+++ b/src/tdhook/__init__.py
@@ -18,4 +18,5 @@ __all__ = [
     "weights",
     "pipeline",
     "artifacts",
+    "stages",
 ]

--- a/src/tdhook/pipeline.py
+++ b/src/tdhook/pipeline.py
@@ -289,9 +289,13 @@ class Pipeline:
         self.validate(artifacts)
         registry = self.artifact_registry or ArtifactRegistry()
         generation = registry.begin_generation()
-        # Inputs are owned by the caller for this execution.  All later
-        # requirements and products are checked against this generation.
-        for key in self._artifact_keys(artifacts):
+        # Only declared pipeline inputs are owned by the caller for this
+        # execution. Retained but undeclared artifacts can belong to another
+        # pipeline sharing this registry and must not cause an ownership clash.
+        initial_required_keys = {
+            key for stage in self.stages for key in stage.required_keys if key in self._artifact_keys(artifacts)
+        }
+        for key in initial_required_keys:
             registry.claim(key, "<pipeline-input>", generation=generation)
         stage_results: list[StageResult] = []
         provenance: list[ArtifactProvenance] = []

--- a/src/tdhook/pipeline.py
+++ b/src/tdhook/pipeline.py
@@ -16,7 +16,7 @@ from torch import nn
 from tensordict import TensorDictBase
 
 from tdhook._types import UnraveledKey
-from tdhook.artifacts import ArtifactAdapter, ArtifactContract, ArtifactProvenance, make_provenance
+from tdhook.artifacts import ArtifactAdapter, ArtifactContract, ArtifactProvenance, ArtifactRegistry, make_provenance
 from tdhook.contexts import HookingContextFactory
 
 
@@ -211,9 +211,16 @@ class AdapterStage(Stage):
 class Pipeline:
     """Validate and execute an ordered sequence of stages."""
 
-    def __init__(self, stages: Sequence[Stage], *, reserved_keys: Iterable[PipelineKey] = RESERVED_KEYS) -> None:
+    def __init__(
+        self,
+        stages: Sequence[Stage],
+        *,
+        reserved_keys: Iterable[PipelineKey] = RESERVED_KEYS,
+        artifact_registry: ArtifactRegistry | None = None,
+    ) -> None:
         self.stages = tuple(stages)
         self.reserved_keys = frozenset(_keys(reserved_keys))
+        self.artifact_registry = artifact_registry
         self._validate_static()
 
     def _validate_static(self) -> None:
@@ -280,6 +287,12 @@ class Pipeline:
         stage_configurations: Mapping[str, Mapping[str, object]] | None = None,
     ) -> PipelineResult:
         self.validate(artifacts)
+        registry = self.artifact_registry or ArtifactRegistry()
+        generation = registry.begin_generation()
+        # Inputs are owned by the caller for this execution.  All later
+        # requirements and products are checked against this generation.
+        for key in self._artifact_keys(artifacts):
+            registry.claim(key, "<pipeline-input>", generation=generation)
         stage_results: list[StageResult] = []
         provenance: list[ArtifactProvenance] = []
         current = artifacts
@@ -287,6 +300,8 @@ class Pipeline:
             missing = [key for key in stage.required_keys if key not in self._artifact_keys(current)]
             if missing:
                 raise ValueError(f"Stage {stage.name!r} requires missing artifact keys: {missing!r}")
+            for key in stage.required_keys:
+                registry.require_fresh(key, generation=generation)
             try:
                 current = stage.run(model, current)
             except Exception as error:
@@ -296,6 +311,9 @@ class Pipeline:
             missing = [key for key in stage.provided_keys if key not in self._artifact_keys(current)]
             if missing:
                 raise ValueError(f"Stage {stage.name!r} did not provide declared artifact keys: {missing!r}")
+            for key in stage.provided_keys:
+                registry.claim(key, stage.name, generation=generation)
+                registry.require_fresh(key, generation=generation)
             stage_results.append(StageResult(stage.name, stage.provided_keys, stage.effects))
             provenance.append(
                 make_provenance(

--- a/src/tdhook/stages.py
+++ b/src/tdhook/stages.py
@@ -7,8 +7,8 @@ the adapter owns the temporary legacy storage used for one model pass.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Iterable
+from dataclasses import dataclass, replace
+from typing import Iterable, Mapping
 
 from torch import nn
 from tensordict import TensorDict, TensorDictBase
@@ -33,6 +33,22 @@ def _execute(factory: HookingContextFactory, model: nn.Module, storage: TensorDi
     with factory.prepare(model) as method:
         result = method(storage)
     return storage if result is None else result
+
+
+def _public_input_key(key: PipelineKey) -> PipelineKey:
+    return ("inputs", key) if isinstance(key, str) else ("inputs", *key)
+
+
+def _attribution_capability(factory: HookingContextFactory) -> StageCapability:
+    """Return model-pass metadata for the concrete attribution factory."""
+    name = type(factory).__name__
+    if name == "ActivationMaximisation":
+        passes = factory._n_steps
+    elif name == "IntegratedGradients":
+        passes = 1 + (2 if factory._compute_convergence_delta else 0)
+    else:
+        passes = 1
+    return replace(AttributionStage.capability, method=name, model_passes=passes)
 
 
 class _FactoryStage(Stage):
@@ -82,7 +98,8 @@ class ActivationCachingStage(_FactoryStage):
         # unaffected after the pipeline pass.
         kwargs = self.factory._hooking_context_kwargs
         previous = kwargs.get("cache")
-        kwargs["cache"] = storage.get("cache") if "cache" in storage else TensorDict()
+        storage.set("cache", previous if previous is not None else TensorDict())
+        kwargs["cache"] = storage.get("cache")
         try:
             _execute(self.factory, model, storage)
             storage.set("cache", kwargs["cache"])
@@ -109,14 +126,27 @@ class AttributionStage(_FactoryStage):
         *,
         input_key: PipelineKey = ("inputs", "input"),
         attribution_key: PipelineKey = ("attributions", "values"),
-        legacy_attribution_key: PipelineKey = "attr",
+        legacy_attribution_key: PipelineKey = ("attr", "input"),
+        baseline_key: PipelineKey | None = None,
+        additional_keys: Mapping[PipelineKey, PipelineKey] | None = None,
     ):
+        requires: dict[str, PipelineKey] = {"input": input_key}
+        storage: dict[str, PipelineKey] = {"input": "input", "attributions": legacy_attribution_key}
+        legacy_baseline = getattr(factory, "_baseline_key", None)
+        if legacy_baseline is not None:
+            requires["baseline"] = baseline_key or _public_input_key(legacy_baseline)
+            storage["baseline"] = (legacy_baseline, "input")
+        for index, legacy_key in enumerate(getattr(factory, "_additional_init_keys", ())):
+            public_key = (additional_keys or {}).get(legacy_key, _public_input_key(legacy_key))
+            requires[f"additional_{index}"] = public_key
+            storage[f"additional_{index}"] = legacy_key
         adapter = ArtifactAdapter(
             "Attribution",
-            ArtifactContract(requires={"input": input_key}, provides={"attributions": attribution_key}),
-            {"input": "input", "attributions": legacy_attribution_key},
+            ArtifactContract(requires=requires, provides={"attributions": attribution_key}),
+            storage,
         )
         super().__init__(name, factory, adapter, effects=("gradient",))
+        self.capability = _attribution_capability(factory)
 
     def run(self, model: nn.Module, artifacts: TensorDictBase) -> TensorDictBase:
         storage = self._storage(artifacts)
@@ -138,11 +168,18 @@ class ProbingStage(_FactoryStage):
         *,
         input_key: PipelineKey = ("inputs", "input"),
         result_key: PipelineKey = ("probes", "results"),
+        additional_keys: Mapping[PipelineKey, PipelineKey] | None = None,
     ):
+        requires: dict[str, PipelineKey] = {"input": input_key}
+        storage: dict[str, PipelineKey] = {"input": "input", "results": "results"}
+        for index, legacy_key in enumerate(getattr(factory, "_additional_keys", ()) or ()):
+            public_key = (additional_keys or {}).get(legacy_key, _public_input_key(legacy_key))
+            requires[f"additional_{index}"] = public_key
+            storage[f"additional_{index}"] = legacy_key
         adapter = ArtifactAdapter(
             "Probing",
-            ArtifactContract(requires={"input": input_key}, provides={"results": result_key}),
-            {"input": "input", "results": "results"},
+            ArtifactContract(requires=requires, provides={"results": result_key}),
+            storage,
         )
         super().__init__(name, factory, adapter, effects=("probe_update",))
         self.results = results
@@ -210,8 +247,12 @@ DOCUMENTED_STAGE_CAPABILITIES = {
 }
 
 
-def capability_for_stage(method: str) -> StageCapability:
-    """Return the executable contract for a supported built-in stage."""
+def capability_for_stage(method: str, *, factory: HookingContextFactory | None = None) -> StageCapability:
+    """Return a built-in capability, deriving attribution passes per factory."""
+    if method == "Attribution":
+        if factory is None:
+            raise ValueError("Attribution capabilities require the concrete factory")
+        return _attribution_capability(factory)
     return BUILTIN_STAGE_CAPABILITIES[method]
 
 

--- a/src/tdhook/stages.py
+++ b/src/tdhook/stages.py
@@ -1,0 +1,235 @@
+"""Executable, typed pipeline stages for the public method families.
+
+The underlying public methods keep their existing TensorDict layouts.  These
+stages are the composition boundary: callers use stable artifact paths while
+the adapter owns the temporary legacy storage used for one model pass.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from torch import nn
+from tensordict import TensorDict, TensorDictBase
+
+from tdhook.artifacts import ArtifactAdapter, ArtifactContract
+from tdhook.contexts import HookingContextFactory
+from tdhook.pipeline import PipelineKey, Stage
+
+
+@dataclass(frozen=True)
+class StageCapability:
+    """Code-backed public capability declaration for a built-in stage."""
+
+    method: str
+    required_keys: tuple[PipelineKey, ...]
+    provided_keys: tuple[PipelineKey, ...]
+    effects: frozenset[str]
+    model_passes: int
+
+
+def _execute(factory: HookingContextFactory, model: nn.Module, storage: TensorDictBase) -> TensorDictBase:
+    with factory.prepare(model) as method:
+        result = method(storage)
+    return storage if result is None else result
+
+
+class _FactoryStage(Stage):
+    """Base class for stages backed by an existing public method factory."""
+
+    def __init__(self, name: str, factory: HookingContextFactory, adapter: ArtifactAdapter, *, effects: Iterable[str]):
+        super().__init__(
+            name, artifact_contract=adapter.contract, effects=("model_execution", *effects), method_id=adapter.method
+        )
+        self.factory = factory
+        self.adapter = adapter
+
+    def _storage(self, artifacts: TensorDictBase) -> TensorDictBase:
+        return self.adapter.prepare(artifacts, TensorDict())
+
+
+class ActivationCachingStage(_FactoryStage):
+    """Execute :class:`ActivationCaching` and publish its actual cache."""
+
+    capability = StageCapability(
+        "ActivationCaching",
+        (("inputs", "input"),),
+        (("activations", "cache"),),
+        frozenset({"model_execution", "activation_read"}),
+        1,
+    )
+
+    def __init__(
+        self,
+        name: str,
+        factory: HookingContextFactory,
+        *,
+        input_key: PipelineKey = ("inputs", "input"),
+        cache_key: PipelineKey = ("activations", "cache"),
+    ):
+        adapter = ArtifactAdapter(
+            "ActivationCaching",
+            ArtifactContract(requires={"input": input_key}, provides={"cache": cache_key}),
+            {"input": "input", "cache": "cache"},
+        )
+        super().__init__(name, factory, adapter, effects=("activation_read",))
+
+    def run(self, model: nn.Module, artifacts: TensorDictBase) -> TensorDictBase:
+        storage = self._storage(artifacts)
+        # ActivationCaching and Adapters expose their context cache through
+        # this documented factory setting. Restore it so standalone reuse is
+        # unaffected after the pipeline pass.
+        kwargs = self.factory._hooking_context_kwargs
+        previous = kwargs.get("cache")
+        kwargs["cache"] = storage.get("cache") if "cache" in storage else TensorDict()
+        try:
+            _execute(self.factory, model, storage)
+            storage.set("cache", kwargs["cache"])
+        finally:
+            kwargs["cache"] = previous
+        return self.adapter.finalize(artifacts, storage)
+
+
+class AttributionStage(_FactoryStage):
+    """Execute an attribution factory and publish its computed attribution."""
+
+    capability = StageCapability(
+        "Attribution",
+        (("inputs", "input"),),
+        (("attributions", "values"),),
+        frozenset({"model_execution", "gradient"}),
+        1,
+    )
+
+    def __init__(
+        self,
+        name: str,
+        factory: HookingContextFactory,
+        *,
+        input_key: PipelineKey = ("inputs", "input"),
+        attribution_key: PipelineKey = ("attributions", "values"),
+        legacy_attribution_key: PipelineKey = "attr",
+    ):
+        adapter = ArtifactAdapter(
+            "Attribution",
+            ArtifactContract(requires={"input": input_key}, provides={"attributions": attribution_key}),
+            {"input": "input", "attributions": legacy_attribution_key},
+        )
+        super().__init__(name, factory, adapter, effects=("gradient",))
+
+    def run(self, model: nn.Module, artifacts: TensorDictBase) -> TensorDictBase:
+        storage = self._storage(artifacts)
+        return self.adapter.finalize(artifacts, _execute(self.factory, model, storage))
+
+
+class ProbingStage(_FactoryStage):
+    """Execute :class:`Probing` and publish the manager that holds its results."""
+
+    capability = StageCapability(
+        "Probing", (("inputs", "input"),), (("probes", "results"),), frozenset({"model_execution", "probe_update"}), 1
+    )
+
+    def __init__(
+        self,
+        name: str,
+        factory: HookingContextFactory,
+        results: object,
+        *,
+        input_key: PipelineKey = ("inputs", "input"),
+        result_key: PipelineKey = ("probes", "results"),
+    ):
+        adapter = ArtifactAdapter(
+            "Probing",
+            ArtifactContract(requires={"input": input_key}, provides={"results": result_key}),
+            {"input": "input", "results": "results"},
+        )
+        super().__init__(name, factory, adapter, effects=("probe_update",))
+        self.results = results
+
+    def run(self, model: nn.Module, artifacts: TensorDictBase) -> TensorDictBase:
+        storage = self._storage(artifacts)
+        _execute(self.factory, model, storage)
+        storage.set("results", self.results)
+        return self.adapter.finalize(artifacts, storage)
+
+
+class WeightInterventionStage(_FactoryStage):
+    """Run weight/adapter intervention factories and publish their model output.
+
+    This deliberately does not label a context activation cache as weights:
+    the output is the real product of an intervention pass.
+    """
+
+    capability = StageCapability(
+        "WeightIntervention",
+        (("inputs", "input"),),
+        (("outputs", "model"),),
+        frozenset({"model_execution", "weight_intervention"}),
+        1,
+    )
+
+    def __init__(
+        self,
+        name: str,
+        factory: HookingContextFactory,
+        *,
+        input_key: PipelineKey = ("inputs", "input"),
+        output_key: PipelineKey = ("outputs", "model"),
+        legacy_output_key: PipelineKey = "output",
+    ):
+        adapter = ArtifactAdapter(
+            "WeightIntervention",
+            ArtifactContract(requires={"input": input_key}, provides={"output": output_key}),
+            {"input": "input", "output": legacy_output_key},
+        )
+        super().__init__(name, factory, adapter, effects=("weight_intervention",))
+
+    def run(self, model: nn.Module, artifacts: TensorDictBase) -> TensorDictBase:
+        storage = self._storage(artifacts)
+        return self.adapter.finalize(artifacts, _execute(self.factory, model, storage))
+
+
+BUILTIN_STAGE_CAPABILITIES = {
+    capability.method: capability
+    for capability in (
+        ActivationCachingStage.capability,
+        AttributionStage.capability,
+        ProbingStage.capability,
+        WeightInterventionStage.capability,
+    )
+}
+
+# Public symbols represented by corresponding composition-matrix rows.  The
+# mapping is deliberately code-owned so documentation tests catch a row that
+# loses its executable implementation contract.
+DOCUMENTED_STAGE_CAPABILITIES = {
+    "ActivationCaching": "ActivationCaching",
+    "Probing": "Probing",
+    "Adapters": "WeightIntervention",
+}
+
+
+def capability_for_stage(method: str) -> StageCapability:
+    """Return the executable contract for a supported built-in stage."""
+    return BUILTIN_STAGE_CAPABILITIES[method]
+
+
+def activation_caching_stage(name: str, factory: HookingContextFactory, **kwargs: object) -> ActivationCachingStage:
+    """Build an executable activation-caching stage."""
+    return ActivationCachingStage(name, factory, **kwargs)
+
+
+def attribution_stage(name: str, factory: HookingContextFactory, **kwargs: object) -> AttributionStage:
+    """Build an executable attribution stage."""
+    return AttributionStage(name, factory, **kwargs)
+
+
+def probing_stage(name: str, factory: HookingContextFactory, results: object, **kwargs: object) -> ProbingStage:
+    """Build an executable probing stage."""
+    return ProbingStage(name, factory, results, **kwargs)
+
+
+def weight_intervention_stage(name: str, factory: HookingContextFactory, **kwargs: object) -> WeightInterventionStage:
+    """Build an executable weight-intervention stage."""
+    return WeightInterventionStage(name, factory, **kwargs)

--- a/tests/test_composition_contract.py
+++ b/tests/test_composition_contract.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from tdhook import attribution, latent, weights
 from tdhook.latent import dimension_estimation
+from tdhook.stages import DOCUMENTED_STAGE_CAPABILITIES, capability_for_stage
 
 
 CAPABILITY_MATRIX = Path(__file__).parents[1] / "docs" / "source" / "_static" / "composition-capabilities.csv"
@@ -54,3 +55,12 @@ def test_callback_and_module_key_capabilities_are_not_undercounted():
     assert rows["GradCAM"]["produced_keys"] == "attribution_key/modules_to_attribute"
     assert "potentially unbounded" in rows["TaskVectors"]["model_passes"]
     assert "both evaluation callbacks" in rows["TaskVectors"]["device_batch_gradient"]
+
+
+def test_documented_built_in_stage_rows_have_executable_capabilities():
+    rows = {row["symbol"] for row in _capability_rows()}
+    assert set(DOCUMENTED_STAGE_CAPABILITIES).issubset(rows)
+    for method in DOCUMENTED_STAGE_CAPABILITIES.values():
+        capability = capability_for_stage(method)
+        assert capability.required_keys
+        assert capability.provided_keys

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 from torch import nn
 from tensordict import TensorDict
@@ -104,6 +105,8 @@ def test_shared_registry_ignores_undeclared_retained_artifacts(default_test_mode
 def test_capabilities_are_executable_contracts():
     assert capability_for_stage("ActivationCaching").provided_keys == (("activations", "cache"),)
     assert capability_for_stage("WeightIntervention").provided_keys == (("outputs", "model"),)
+    with pytest.raises(ValueError, match="concrete factory"):
+        capability_for_stage("Attribution")
 
 
 def test_public_stage_factories_build_the_typed_stages():

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -11,7 +11,11 @@ from tdhook.stages import (
     AttributionStage,
     ProbingStage,
     WeightInterventionStage,
+    activation_caching_stage,
+    attribution_stage,
     capability_for_stage,
+    probing_stage,
+    weight_intervention_stage,
 )
 from tdhook.contexts import HookingContextFactory
 
@@ -70,3 +74,10 @@ def test_pipeline_claims_and_checks_artifact_generation_during_execution(default
 def test_capabilities_are_executable_contracts():
     assert capability_for_stage("ActivationCaching").provided_keys == (("activations", "cache"),)
     assert capability_for_stage("WeightIntervention").provided_keys == (("outputs", "model"),)
+
+
+def test_public_stage_factories_build_the_typed_stages():
+    assert isinstance(activation_caching_stage("cache", ActivationCaching("0")), ActivationCachingStage)
+    assert isinstance(attribution_stage("attr", HookingContextFactory()), AttributionStage)
+    assert isinstance(probing_stage("probe", HookingContextFactory(), object()), ProbingStage)
+    assert isinstance(weight_intervention_stage("intervene", HookingContextFactory()), WeightInterventionStage)

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -105,6 +105,7 @@ def test_shared_registry_ignores_undeclared_retained_artifacts(default_test_mode
 def test_capabilities_are_executable_contracts():
     assert capability_for_stage("ActivationCaching").provided_keys == (("activations", "cache"),)
     assert capability_for_stage("WeightIntervention").provided_keys == (("outputs", "model"),)
+    assert capability_for_stage("Attribution", factory=IntegratedGradients(n_steps=2)).model_passes == 1
     with pytest.raises(ValueError, match="concrete factory"):
         capability_for_stage("Attribution")
 

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -1,0 +1,72 @@
+import torch
+from torch import nn
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+
+from tdhook.artifacts import ArtifactRegistry
+from tdhook.latent import ActivationCaching
+from tdhook.pipeline import Pipeline, TransformStage
+from tdhook.stages import (
+    ActivationCachingStage,
+    AttributionStage,
+    ProbingStage,
+    WeightInterventionStage,
+    capability_for_stage,
+)
+from tdhook.contexts import HookingContextFactory
+
+
+def _artifacts():
+    return TensorDict({"inputs": {"input": torch.ones(2, 3)}}, batch_size=[2])
+
+
+def test_activation_caching_stage_executes_a_real_method_and_publishes_its_cache():
+    model = nn.Sequential(nn.Linear(3, 3), nn.ReLU())
+    result = Pipeline([ActivationCachingStage("cache", ActivationCaching("0"))]).run(model, _artifacts())
+
+    assert "0" in result.artifacts[("activations", "cache")]
+    assert result.provenance[0].method == "ActivationCaching"
+
+
+def test_builtin_stages_publish_method_accurate_contracts_without_callbacks():
+    # A TensorDictModule lets the unmodified factory route the legacy output
+    # name each public method already uses.
+    attribution_model = TensorDictModule(nn.Identity(), in_keys=["input"], out_keys=["attr"])
+    attr_result = Pipeline([AttributionStage("attr", HookingContextFactory())]).run(attribution_model, _artifacts())
+    assert torch.equal(attr_result.artifacts[("attributions", "values")], torch.ones(2, 3))
+
+    results = object()
+    probe_result = Pipeline([ProbingStage("probe", HookingContextFactory(), results)]).run(
+        TensorDictModule(nn.Identity(), in_keys=["input"], out_keys=["ignored"]), _artifacts()
+    )
+    assert probe_result.artifacts[("probes", "results")] == results
+
+    output_result = Pipeline([WeightInterventionStage("intervene", HookingContextFactory())]).run(
+        TensorDictModule(nn.Identity(), in_keys=["input"], out_keys=["output"]), _artifacts()
+    )
+    assert torch.equal(output_result.artifacts[("outputs", "model")], torch.ones(2, 3))
+    assert ("interventions", "weights") not in output_result.artifacts.keys(include_nested=True)
+
+
+def test_pipeline_claims_and_checks_artifact_generation_during_execution(default_test_model):
+    registry = ArtifactRegistry()
+    pipeline = Pipeline(
+        [
+            TransformStage(
+                "copy",
+                lambda td: td.set(("outputs", "value"), td[("inputs", "input")]),
+                required_keys=[("inputs", "input")],
+                provided_keys=[("outputs", "value")],
+            )
+        ],
+        artifact_registry=registry,
+    )
+
+    result = pipeline.run(default_test_model, _artifacts())
+    registry.require_fresh(("outputs", "value"), generation=1)
+    assert torch.equal(result.artifacts[("outputs", "value")], torch.ones(2, 3))
+
+
+def test_capabilities_are_executable_contracts():
+    assert capability_for_stage("ActivationCaching").provided_keys == (("activations", "cache"),)
+    assert capability_for_stage("WeightIntervention").provided_keys == (("outputs", "model"),)

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -4,7 +4,8 @@ from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
 
 from tdhook.artifacts import ArtifactRegistry
-from tdhook.latent import ActivationCaching
+from tdhook.attribution import ActivationMaximisation, IntegratedGradients
+from tdhook.latent import ActivationCaching, Probing
 from tdhook.pipeline import Pipeline, TransformStage
 from tdhook.stages import (
     ActivationCachingStage,
@@ -35,7 +36,7 @@ def test_activation_caching_stage_executes_a_real_method_and_publishes_its_cache
 def test_builtin_stages_publish_method_accurate_contracts_without_callbacks():
     # A TensorDictModule lets the unmodified factory route the legacy output
     # name each public method already uses.
-    attribution_model = TensorDictModule(nn.Identity(), in_keys=["input"], out_keys=["attr"])
+    attribution_model = TensorDictModule(nn.Identity(), in_keys=["input"], out_keys=[("attr", "input")])
     attr_result = Pipeline([AttributionStage("attr", HookingContextFactory())]).run(attribution_model, _artifacts())
     assert torch.equal(attr_result.artifacts[("attributions", "values")], torch.ones(2, 3))
 
@@ -71,6 +72,35 @@ def test_pipeline_claims_and_checks_artifact_generation_during_execution(default
     assert torch.equal(result.artifacts[("outputs", "value")], torch.ones(2, 3))
 
 
+def test_shared_registry_ignores_undeclared_retained_artifacts(default_test_model):
+    registry = ArtifactRegistry()
+    first = Pipeline(
+        [
+            TransformStage(
+                "first",
+                lambda td: td.set(("outputs", "retained"), td[("inputs", "input")]),
+                required_keys=[("inputs", "input")],
+                provided_keys=[("outputs", "retained")],
+            )
+        ],
+        artifact_registry=registry,
+    )
+    retained = first.run(default_test_model, _artifacts()).artifacts
+    second = Pipeline(
+        [
+            TransformStage(
+                "second",
+                lambda td: td.set(("metrics", "value"), td[("inputs", "input")].sum(-1)),
+                required_keys=[("inputs", "input")],
+                provided_keys=[("metrics", "value")],
+            )
+        ],
+        artifact_registry=registry,
+    )
+
+    assert "value" in second.run(default_test_model, retained).artifacts["metrics"]
+
+
 def test_capabilities_are_executable_contracts():
     assert capability_for_stage("ActivationCaching").provided_keys == (("activations", "cache"),)
     assert capability_for_stage("WeightIntervention").provided_keys == (("outputs", "model"),)
@@ -81,3 +111,57 @@ def test_public_stage_factories_build_the_typed_stages():
     assert isinstance(attribution_stage("attr", HookingContextFactory()), AttributionStage)
     assert isinstance(probing_stage("probe", HookingContextFactory(), object()), ProbingStage)
     assert isinstance(weight_intervention_stage("intervene", HookingContextFactory()), WeightInterventionStage)
+
+
+def test_attribution_stage_maps_baseline_and_additional_inputs_and_reports_passes(default_test_model):
+    factory = IntegratedGradients(
+        n_steps=2,
+        compute_convergence_delta=True,
+        additional_init_keys=["label"],
+        init_attr_targets=lambda outputs, extra: outputs,
+    )
+    stage = AttributionStage("integrated-gradients", factory)
+    assert stage.required_keys == (("inputs", "input"), ("inputs", "baseline"), ("inputs", "label"))
+    assert stage.capability.model_passes == 3
+
+    artifacts = TensorDict(
+        {
+            "inputs": {
+                "input": torch.ones(2, 10),
+                "baseline": torch.zeros(2, 10),
+                "label": torch.zeros(2, dtype=torch.long),
+            }
+        },
+        batch_size=[2],
+    )
+    result = Pipeline([stage]).run(default_test_model, artifacts)
+    assert result.artifacts[("attributions", "values")].shape == (2, 10)
+    assert AttributionStage("maximise", ActivationMaximisation(["linear1"], n_steps=4)).capability.model_passes == 4
+
+
+def test_probing_stage_maps_configured_auxiliary_inputs(default_test_model):
+    observed = []
+
+    class RecordingProbe:
+        def step(self, data, **kwargs):
+            observed.append(kwargs)
+
+    factory = Probing("linear1", lambda *_: RecordingProbe(), additional_keys=["labels", "step_type"])
+    stage = ProbingStage("probe", factory, object())
+    artifacts = TensorDict(
+        {"inputs": {"input": torch.ones(2, 10), "labels": torch.ones(2), "step_type": "fit"}},
+        batch_size=[2],
+    )
+    Pipeline([stage]).run(default_test_model, artifacts)
+    assert stage.required_keys == (("inputs", "input"), ("inputs", "labels"), ("inputs", "step_type"))
+    assert observed[0]["labels"].equal(torch.ones(2))
+    assert observed[0]["step_type"] == "fit"
+
+
+def test_activation_caching_stage_retains_configured_cache(default_test_model):
+    cache = TensorDict()
+    factory = ActivationCaching("linear1", cache=cache, clear_cache=False)
+    Pipeline([ActivationCachingStage("cache", factory)]).run(
+        default_test_model, TensorDict({"inputs": {"input": torch.ones(2, 10)}}, batch_size=[2])
+    )
+    assert "linear1" in cache


### PR DESCRIPTION
## Summary

Adds first-class executable pipeline stages for activation caching, attribution, probing, and weight/adapter interventions. The stages translate existing public-method storage into typed public artifact contracts, so callers no longer need custom `AdapterStage` callbacks for these core families.

Pipeline execution now claims input and produced artifacts in an `ArtifactRegistry` generation and freshness-checks every declared dependency and product. The composition documentation and tests connect documented built-in rows to code-backed capability records.

The weight intervention stage publishes the actual model output of the intervention pass; it does not mislabel an activation cache as intervention weights.

Closes #69.

## Validation

- `uv run pytest tests -q` (441 passed)
- Pre-commit hooks: YAML/JSON/TOML checks, EOF, whitespace, docstring, Ruff check, and Ruff format

## Notes

- The broad `uv run pytest -q` invocation discovers the repository's ignored test tree and fails during collection because it duplicates `tests.conftest`; the scoped project suite above is clean.