### PR TITLE
Add capability-driven execution planning

### DIFF
--- a/docs/source/composition.rst
+++ b/docs/source/composition.rst
@@ -30,6 +30,30 @@ Every method stage uses the same ``with factory.prepare(model)`` lifecycle as
 standalone code.  Context cleanup is therefore guaranteed if setup or a later
 stage raises.
 
+Preflight planning
+------------------
+
+``Pipeline.plan()`` returns an :class:`~tdhook.pipeline.ExecutionPlan` before
+the first hook is registered or model call is made.  Each planned run names
+its stages, artifact inputs and outputs, effects, gradient mode,
+device/batch constraints, and model-pass budget.  This makes demo pass budgets
+inspectable without executing them:
+
+.. code-block:: python
+
+   plan = pipeline.plan(artifacts)
+   print(plan.model_passes)
+   for run in plan.runs:
+       print(run.stages, run.model_passes, run.coalesced)
+
+The planner is deliberately conservative.  Unknown pairs and stages separated
+by an artifact dependency receive separate runs.  Adjacent ``MethodStage``
+objects co-execute only when both opt into the same non-empty
+``coexecution_key`` and agree on model keys, pass count, effects, context
+specialisation, and device/batch requirements.  A shared run uses
+``HookGroup`` and retains its rollback and cleanup guarantees.  This is a
+linear execution plan, not a general DAG scheduler.
+
 .. note::
 
    This is the Phase 0 architecture decision for `issue 57

--- a/src/tdhook/pipeline.py
+++ b/src/tdhook/pipeline.py
@@ -125,6 +125,8 @@ class Stage(ABC):
         self.model_passes = inferred_passes if model_passes is None else model_passes
         if self.model_passes < 0:
             raise ValueError("Stage model_passes must be non-negative")
+        if "model_execution" in self.effects and self.model_passes == 0:
+            raise ValueError("Model-executing stages require positive model_passes")
         self.gradient_mode = gradient_mode
         self.device_batch_constraints = tuple(device_batch_constraints)
         self.coexecution_key = coexecution_key
@@ -327,10 +329,10 @@ class Pipeline:
     @staticmethod
     def _can_coalesce(stages: Sequence[Stage]) -> bool:
         """Return whether explicit capabilities prove one shared model run safe."""
-        if not stages or not all(isinstance(stage, MethodStage) for stage in stages):
+        if not stages or not all(type(stage) is MethodStage for stage in stages):
             return False
         first = stages[0]
-        if first.coexecution_key is None or any(stage.coexecution_key != first.coexecution_key for stage in stages):
+        if not first.coexecution_key or any(stage.coexecution_key != first.coexecution_key for stage in stages):
             return False
         if any(stage.model_passes != 1 for stage in stages):
             return False
@@ -356,6 +358,12 @@ class Pipeline:
             produced.update(stage.provided_keys)
             effects.update(stage.effects)
             incompatible.update(stage.incompatible_effects)
+            # HookGroup owns one context and does not enter child contexts.
+            # Factories that configure context or wrapper state per instance
+            # therefore need their standalone lifecycle until they expose an
+            # explicit shared-group contract.
+            if stage.factory._hooking_context_kwargs or stage.factory._hooked_module_kwargs:
+                return False
         try:
             HookGroup(*(stage.factory for stage in stages))
         except ValueError:
@@ -394,7 +402,7 @@ class Pipeline:
         index = 0
         while index < len(self.stages):
             candidate = [self.stages[index]]
-            if isinstance(candidate[0], MethodStage) and candidate[0].coexecution_key is not None:
+            if type(candidate[0]) is MethodStage and candidate[0].coexecution_key:
                 while index + len(candidate) < len(self.stages):
                     next_stage = self.stages[index + len(candidate)]
                     if not self._can_coalesce([*candidate, next_stage]):

--- a/src/tdhook/pipeline.py
+++ b/src/tdhook/pipeline.py
@@ -10,14 +10,14 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Callable, Iterable, Mapping, Sequence
+from typing import Callable, Iterable, Literal, Mapping, Sequence
 
 from torch import nn
 from tensordict import TensorDictBase
 
 from tdhook._types import UnraveledKey
 from tdhook.artifacts import ArtifactAdapter, ArtifactContract, ArtifactProvenance, ArtifactRegistry, make_provenance
-from tdhook.contexts import HookingContextFactory
+from tdhook.contexts import HookGroup, HookingContextFactory
 
 
 PipelineKey = UnraveledKey
@@ -60,6 +60,34 @@ class PipelineResult:
     artifacts: TensorDictBase
     stages: tuple[StageResult, ...]
     provenance: tuple[ArtifactProvenance, ...] = ()
+    plan: ExecutionPlan | None = None
+
+
+@dataclass(frozen=True)
+class PlannedRun:
+    """One inspectable execution unit produced by pipeline preflight."""
+
+    stages: tuple[str, ...]
+    kind: Literal["model", "transform"]
+    model_passes: int
+    gradient_mode: str
+    device_batch_constraints: tuple[str, ...]
+    effects: frozenset[str]
+    required_keys: tuple[PipelineKey, ...]
+    provided_keys: tuple[PipelineKey, ...]
+    coalesced: bool = False
+
+
+@dataclass(frozen=True)
+class ExecutionPlan:
+    """A deterministic plan created before hooks or model execution."""
+
+    runs: tuple[PlannedRun, ...]
+
+    @property
+    def model_passes(self) -> int:
+        """Total model-pass budget declared by the planned runs."""
+        return sum(run.model_passes for run in self.runs)
 
 
 class Stage(ABC):
@@ -75,6 +103,10 @@ class Stage(ABC):
         incompatible_effects: Iterable[str] = (),
         artifact_contract: ArtifactContract | None = None,
         method_id: str | None = None,
+        model_passes: int | None = None,
+        gradient_mode: str = "optional",
+        device_batch_constraints: Iterable[str] = (),
+        coexecution_key: str | None = None,
     ) -> None:
         if not name:
             raise ValueError("A stage must have a non-empty name")
@@ -89,6 +121,13 @@ class Stage(ABC):
         self.provided_keys = _keys(artifact_contract.provided_keys if artifact_contract else provided_keys)
         self.effects = frozenset(effects)
         self.incompatible_effects = frozenset(incompatible_effects)
+        inferred_passes = 1 if "model_execution" in self.effects else 0
+        self.model_passes = inferred_passes if model_passes is None else model_passes
+        if self.model_passes < 0:
+            raise ValueError("Stage model_passes must be non-negative")
+        self.gradient_mode = gradient_mode
+        self.device_batch_constraints = tuple(device_batch_constraints)
+        self.coexecution_key = coexecution_key
 
     @abstractmethod
     def run(self, model: nn.Module, artifacts: TensorDictBase) -> TensorDictBase:
@@ -111,6 +150,10 @@ class MethodStage(Stage):
         model_out_keys: Iterable[PipelineKey] | None = None,
         artifact_contract: ArtifactContract | None = None,
         method_id: str | None = None,
+        model_passes: int = 1,
+        gradient_mode: str = "optional",
+        device_batch_constraints: Iterable[str] = (),
+        coexecution_key: str | None = None,
     ) -> None:
         super().__init__(
             name,
@@ -120,6 +163,10 @@ class MethodStage(Stage):
             incompatible_effects=incompatible_effects,
             artifact_contract=artifact_contract,
             method_id=type(factory).__name__ if method_id is None else method_id,
+            model_passes=model_passes,
+            gradient_mode=gradient_mode,
+            device_batch_constraints=device_batch_constraints,
+            coexecution_key=coexecution_key,
         )
         self.factory = factory
         self.model_in_keys = None if model_in_keys is None else _keys(model_in_keys)
@@ -277,6 +324,99 @@ class Pipeline:
                 raise ValueError(f"Stage {stage.name!r} writes existing artifact keys: {collisions!r}")
             available.update(stage.provided_keys)
 
+    @staticmethod
+    def _can_coalesce(stages: Sequence[Stage]) -> bool:
+        """Return whether explicit capabilities prove one shared model run safe."""
+        if not stages or not all(isinstance(stage, MethodStage) for stage in stages):
+            return False
+        first = stages[0]
+        if first.coexecution_key is None or any(stage.coexecution_key != first.coexecution_key for stage in stages):
+            return False
+        if any(stage.model_passes != 1 for stage in stages):
+            return False
+        if any(
+            (stage.model_in_keys, stage.model_out_keys) != (first.model_in_keys, first.model_out_keys)
+            for stage in stages[1:]
+        ):
+            return False
+        if any(
+            (stage.gradient_mode, stage.device_batch_constraints)
+            != (first.gradient_mode, first.device_batch_constraints)
+            for stage in stages[1:]
+        ):
+            return False
+        produced: set[PipelineKey] = set()
+        effects: set[str] = set()
+        incompatible: set[str] = set()
+        for stage in stages:
+            if produced.intersection(stage.required_keys):
+                return False
+            if stage.incompatible_effects.intersection(effects) or stage.effects.intersection(incompatible):
+                return False
+            produced.update(stage.provided_keys)
+            effects.update(stage.effects)
+            incompatible.update(stage.incompatible_effects)
+        try:
+            HookGroup(*(stage.factory for stage in stages))
+        except ValueError:
+            return False
+        return True
+
+    @staticmethod
+    def _planned_run(stages: Sequence[Stage], *, coalesced: bool = False) -> PlannedRun:
+        kind = "model" if any(stage.model_passes for stage in stages) else "transform"
+        gradient_modes = {stage.gradient_mode for stage in stages}
+        gradient_mode = next(iter(gradient_modes)) if len(gradient_modes) == 1 else "mixed"
+        return PlannedRun(
+            stages=tuple(stage.name for stage in stages),
+            kind=kind,
+            model_passes=1 if coalesced else sum(stage.model_passes for stage in stages),
+            gradient_mode=gradient_mode,
+            device_batch_constraints=tuple(
+                dict.fromkeys(constraint for stage in stages for constraint in stage.device_batch_constraints)
+            ),
+            effects=frozenset(effect for stage in stages for effect in stage.effects),
+            required_keys=tuple(dict.fromkeys(key for stage in stages for key in stage.required_keys)),
+            provided_keys=tuple(dict.fromkeys(key for stage in stages for key in stage.provided_keys)),
+            coalesced=coalesced,
+        )
+
+    def plan(self, artifacts: TensorDictBase | None = None) -> ExecutionPlan:
+        """Return the conservative execution plan without preparing the model.
+
+        Unknown method pairs are split. Adjacent :class:`MethodStage` objects
+        share a run only when they declare the same non-empty
+        ``coexecution_key`` and their remaining execution contracts agree.
+        """
+        if artifacts is not None:
+            self.validate(artifacts)
+        runs: list[PlannedRun] = []
+        index = 0
+        while index < len(self.stages):
+            candidate = [self.stages[index]]
+            if isinstance(candidate[0], MethodStage) and candidate[0].coexecution_key is not None:
+                while index + len(candidate) < len(self.stages):
+                    next_stage = self.stages[index + len(candidate)]
+                    if not self._can_coalesce([*candidate, next_stage]):
+                        break
+                    candidate.append(next_stage)
+            coalesced = len(candidate) > 1
+            runs.append(self._planned_run(candidate, coalesced=coalesced))
+            index += len(candidate)
+        return ExecutionPlan(tuple(runs))
+
+    @staticmethod
+    def _run_coalesced(stages: Sequence[MethodStage], model: nn.Module, artifacts: TensorDictBase) -> TensorDictBase:
+        first = stages[0]
+        factory = HookGroup(*(stage.factory for stage in stages))
+        with factory.prepare(
+            model,
+            in_keys=None if first.model_in_keys is None else list(first.model_in_keys),
+            out_keys=None if first.model_out_keys is None else list(first.model_out_keys),
+        ) as method:
+            result = method(artifacts)
+        return artifacts if result is None else result
+
     def run(
         self,
         model: nn.Module,
@@ -286,7 +426,7 @@ class Pipeline:
         seed: int | None = None,
         stage_configurations: Mapping[str, Mapping[str, object]] | None = None,
     ) -> PipelineResult:
-        self.validate(artifacts)
+        plan = self.plan(artifacts)
         registry = self.artifact_registry or ArtifactRegistry()
         generation = registry.begin_generation()
         # Only declared pipeline inputs are owned by the caller for this
@@ -300,34 +440,43 @@ class Pipeline:
         stage_results: list[StageResult] = []
         provenance: list[ArtifactProvenance] = []
         current = artifacts
-        for stage in self.stages:
-            missing = [key for key in stage.required_keys if key not in self._artifact_keys(current)]
-            if missing:
-                raise ValueError(f"Stage {stage.name!r} requires missing artifact keys: {missing!r}")
-            for key in stage.required_keys:
-                registry.require_fresh(key, generation=generation)
+        stage_by_name = {stage.name: stage for stage in self.stages}
+        for planned_run in plan.runs:
+            run_stages = [stage_by_name[name] for name in planned_run.stages]
+            for stage in run_stages:
+                missing = [key for key in stage.required_keys if key not in self._artifact_keys(current)]
+                if missing:
+                    raise ValueError(f"Stage {stage.name!r} requires missing artifact keys: {missing!r}")
+                for key in stage.required_keys:
+                    registry.require_fresh(key, generation=generation)
             try:
-                current = stage.run(model, current)
+                if planned_run.coalesced:
+                    current = self._run_coalesced(run_stages, model, current)
+                else:
+                    current = run_stages[0].run(model, current)
             except Exception as error:
-                raise RuntimeError(f"Pipeline stage {stage.name!r} failed: {error}") from error
+                names = ", ".join(repr(stage.name) for stage in run_stages)
+                raise RuntimeError(f"Pipeline planned run [{names}] failed: {error}") from error
             if not isinstance(current, TensorDictBase):
-                raise TypeError(f"Stage {stage.name!r} returned {type(current).__name__}, not a TensorDict")
-            missing = [key for key in stage.provided_keys if key not in self._artifact_keys(current)]
-            if missing:
-                raise ValueError(f"Stage {stage.name!r} did not provide declared artifact keys: {missing!r}")
-            for key in stage.provided_keys:
-                registry.claim(key, stage.name, generation=generation)
-                registry.require_fresh(key, generation=generation)
-            stage_results.append(StageResult(stage.name, stage.provided_keys, stage.effects))
-            provenance.append(
-                make_provenance(
-                    stage=stage.name,
-                    method=stage.method_id,
-                    configuration=(stage_configurations or {}).get(stage.name),
-                    model_id=model_id,
-                    seed=seed,
-                    parents=stage.required_keys,
-                    model=model,
+                names = ", ".join(repr(stage.name) for stage in run_stages)
+                raise TypeError(f"Planned run [{names}] returned {type(current).__name__}, not a TensorDict")
+            for stage in run_stages:
+                missing = [key for key in stage.provided_keys if key not in self._artifact_keys(current)]
+                if missing:
+                    raise ValueError(f"Stage {stage.name!r} did not provide declared artifact keys: {missing!r}")
+                for key in stage.provided_keys:
+                    registry.claim(key, stage.name, generation=generation)
+                    registry.require_fresh(key, generation=generation)
+                stage_results.append(StageResult(stage.name, stage.provided_keys, stage.effects))
+                provenance.append(
+                    make_provenance(
+                        stage=stage.name,
+                        method=stage.method_id,
+                        configuration=(stage_configurations or {}).get(stage.name),
+                        model_id=model_id,
+                        seed=seed,
+                        parents=stage.required_keys,
+                        model=model,
+                    )
                 )
-            )
-        return PipelineResult(current, tuple(stage_results), tuple(provenance))
+        return PipelineResult(current, tuple(stage_results), tuple(provenance), plan)

--- a/src/tdhook/stages.py
+++ b/src/tdhook/stages.py
@@ -27,6 +27,8 @@ class StageCapability:
     provided_keys: tuple[PipelineKey, ...]
     effects: frozenset[str]
     model_passes: int
+    gradient_mode: str = "optional"
+    device_batch_constraints: tuple[str, ...] = ()
 
 
 def _execute(factory: HookingContextFactory, model: nn.Module, storage: TensorDictBase) -> TensorDictBase:
@@ -55,8 +57,15 @@ class _FactoryStage(Stage):
     """Base class for stages backed by an existing public method factory."""
 
     def __init__(self, name: str, factory: HookingContextFactory, adapter: ArtifactAdapter, *, effects: Iterable[str]):
+        capability = type(self).capability
         super().__init__(
-            name, artifact_contract=adapter.contract, effects=("model_execution", *effects), method_id=adapter.method
+            name,
+            artifact_contract=adapter.contract,
+            effects=("model_execution", *effects),
+            method_id=adapter.method,
+            model_passes=capability.model_passes,
+            gradient_mode=capability.gradient_mode,
+            device_batch_constraints=capability.device_batch_constraints,
         )
         self.factory = factory
         self.adapter = adapter
@@ -74,6 +83,8 @@ class ActivationCachingStage(_FactoryStage):
         (("activations", "cache"),),
         frozenset({"model_execution", "activation_read"}),
         1,
+        "optional",
+        ("cached tensors retain the source device and batch shape",),
     )
 
     def __init__(
@@ -117,6 +128,8 @@ class AttributionStage(_FactoryStage):
         (("attributions", "values"),),
         frozenset({"model_execution", "gradient"}),
         1,
+        "required",
+        ("inputs, targets, and captured values must share a device",),
     )
 
     def __init__(
@@ -147,6 +160,9 @@ class AttributionStage(_FactoryStage):
         )
         super().__init__(name, factory, adapter, effects=("gradient",))
         self.capability = _attribution_capability(factory)
+        self.model_passes = self.capability.model_passes
+        self.gradient_mode = self.capability.gradient_mode
+        self.device_batch_constraints = self.capability.device_batch_constraints
 
     def run(self, model: nn.Module, artifacts: TensorDictBase) -> TensorDictBase:
         storage = self._storage(artifacts)
@@ -157,7 +173,13 @@ class ProbingStage(_FactoryStage):
     """Execute :class:`Probing` and publish the manager that holds its results."""
 
     capability = StageCapability(
-        "Probing", (("inputs", "input"),), (("probes", "results"),), frozenset({"model_execution", "probe_update"}), 1
+        "Probing",
+        (("inputs", "input"),),
+        (("probes", "results"),),
+        frozenset({"model_execution", "probe_update"}),
+        1,
+        "optional",
+        ("activation, label, and estimator devices must be compatible",),
     )
 
     def __init__(
@@ -204,6 +226,8 @@ class WeightInterventionStage(_FactoryStage):
         (("outputs", "model"),),
         frozenset({"model_execution", "weight_intervention"}),
         1,
+        "optional",
+        ("intervention tensors must match target device, shape, and dtype",),
     )
 
     def __init__(

--- a/src/tdhook/stages.py
+++ b/src/tdhook/stages.py
@@ -43,10 +43,14 @@ def _public_input_key(key: PipelineKey) -> PipelineKey:
 
 def _attribution_capability(factory: HookingContextFactory) -> StageCapability:
     """Return model-pass metadata for the concrete attribution factory."""
+    # Keep these imports local: the public attribution package imports its
+    # method modules, while stages only needs their runtime type here.
+    from tdhook.attribution import ActivationMaximisation, IntegratedGradients
+
     name = type(factory).__name__
-    if name == "ActivationMaximisation":
+    if isinstance(factory, ActivationMaximisation):
         passes = factory._n_steps
-    elif name == "IntegratedGradients":
+    elif isinstance(factory, IntegratedGradients):
         passes = 1 + (2 if factory._compute_convergence_delta else 0)
     else:
         passes = 1

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -4,6 +4,7 @@ from torch import nn
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
 
+from tdhook.attribution import ActivationMaximisation
 from tdhook.contexts import HookingContextFactory, HookingContextWithCache
 from tdhook.artifacts import ArtifactAdapter, ArtifactContract
 from tdhook.hooks import MultiHookHandle
@@ -131,6 +132,46 @@ def test_plan_does_not_prepare_factories_and_isolates_specialised_contexts(defau
     assert not specialised.prepared
 
 
+def test_plan_splits_empty_keys_subclasses_and_factories_with_instance_setup():
+    class CustomMethodStage(MethodStage):
+        def run(self, model, artifacts):
+            return super().run(model, artifacts)
+
+    pipelines = [
+        (
+            Pipeline(
+                [
+                    MethodStage("first", AddOne(), coexecution_key=""),
+                    MethodStage("second", TimesTwo(), coexecution_key=""),
+                ]
+            ),
+            [("first",), ("second",)],
+        ),
+        (
+            Pipeline(
+                [
+                    CustomMethodStage("first", AddOne(), coexecution_key="safe"),
+                    CustomMethodStage("second", TimesTwo(), coexecution_key="safe"),
+                ]
+            ),
+            [("first",), ("second",)],
+        ),
+        (
+            Pipeline(
+                [
+                    MethodStage("configured", ActivationMaximisation(["linear"], n_steps=1), coexecution_key="safe"),
+                    MethodStage("second", TimesTwo(), coexecution_key="safe"),
+                ]
+            ),
+            [("configured",), ("second",)],
+        ),
+    ]
+
+    for pipeline, expected_runs in pipelines:
+        plan = pipeline.plan()
+        assert [run.stages for run in plan.runs] == expected_runs
+
+
 @pytest.mark.parametrize(
     "stages",
     [
@@ -159,9 +200,10 @@ def test_coalescing_rejects_each_incomplete_compatibility_contract(stages):
     assert not Pipeline._can_coalesce(stages)
 
 
-def test_stage_rejects_a_negative_model_pass_declaration():
-    with pytest.raises(ValueError, match="model_passes"):
-        MethodStage("invalid", AddOne(), model_passes=-1)
+@pytest.mark.parametrize("model_passes", [-1, 0])
+def test_model_executing_stage_rejects_a_non_positive_pass_declaration(model_passes):
+    with pytest.raises(ValueError, match="model_passes|positive"):
+        MethodStage("invalid", AddOne(), model_passes=model_passes)
 
 
 def test_transform_then_method_with_nested_key(default_test_model):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,9 +1,10 @@
 import pytest
 import torch
+from torch import nn
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
 
-from tdhook.contexts import HookingContextFactory
+from tdhook.contexts import HookingContextFactory, HookingContextWithCache
 from tdhook.artifacts import ArtifactAdapter, ArtifactContract
 from tdhook.hooks import MultiHookHandle
 from tdhook.modules import HookedModule
@@ -13,6 +14,22 @@ from tdhook.pipeline import AdapterStage, MethodStage, Pipeline, Stage, Transfor
 class AddOne(HookingContextFactory):
     def _hook_module(self, module: HookedModule) -> MultiHookHandle:
         return module.register_submodule_hook("", lambda module, args, output: output + 1, direction="fwd")
+
+
+class TimesTwo(HookingContextFactory):
+    def _hook_module(self, module: HookedModule) -> MultiHookHandle:
+        return module.register_submodule_hook("", lambda module, args, output: output * 2, direction="fwd")
+
+
+class CountingModel(nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+        self.calls = 0
+
+    def forward(self, value):
+        self.calls += 1
+        return self.model(value)
 
 
 def test_method_then_transform(default_test_model):
@@ -34,6 +51,84 @@ def test_method_then_transform(default_test_model):
     assert torch.allclose(result.artifacts["output"], default_test_model(torch.ones(2, 10)) + 1)
     assert result.artifacts["summary"].shape == (2,)
     assert [stage.name for stage in result.stages] == ["predict", "summarise"]
+
+
+def test_plan_coalesces_only_explicitly_compatible_methods_and_counts_one_pass(default_test_model):
+    model = CountingModel(default_test_model)
+    artifacts = TensorDict({"input": torch.ones(2, 10)}, batch_size=[2])
+    pipeline = Pipeline(
+        [
+            MethodStage(
+                "add",
+                AddOne(),
+                required_keys=["input"],
+                coexecution_key="ordered-output-hooks-v1",
+                device_batch_constraints=["same input batch"],
+            ),
+            MethodStage(
+                "multiply",
+                TimesTwo(),
+                required_keys=["input"],
+                provided_keys=["output"],
+                coexecution_key="ordered-output-hooks-v1",
+                device_batch_constraints=["same input batch"],
+            ),
+        ]
+    )
+
+    first_plan = pipeline.plan(artifacts)
+    assert first_plan == pipeline.plan(artifacts)
+    assert first_plan.model_passes == 1
+    assert first_plan.runs[0].stages == ("add", "multiply")
+    assert first_plan.runs[0].coalesced
+    assert first_plan.runs[0].device_batch_constraints == ("same input batch",)
+
+    result = pipeline.run(model, artifacts)
+
+    assert model.calls == 1
+    assert result.plan == first_plan
+    assert torch.allclose(result.artifacts["output"], (default_test_model(torch.ones(2, 10)) + 1) * 2)
+
+
+def test_plan_splits_unknown_pairs_and_artifact_boundaries(default_test_model):
+    pipeline = Pipeline(
+        [
+            MethodStage("first", AddOne(), required_keys=["input"], provided_keys=["first_output"]),
+            MethodStage("second", TimesTwo(), required_keys=["first_output"], provided_keys=["output"]),
+        ]
+    )
+
+    plan = pipeline.plan(TensorDict({"input": torch.ones(2, 10)}, batch_size=[2]))
+
+    assert [run.stages for run in plan.runs] == [("first",), ("second",)]
+    assert plan.model_passes == 2
+    assert not any(run.coalesced for run in plan.runs)
+
+
+def test_plan_does_not_prepare_factories_and_isolates_specialised_contexts(default_test_model):
+    class PreparedOnlyDuringExecution(HookingContextFactory):
+        prepared = False
+
+        def _prepare_module(self, module, in_keys, out_keys, extra_relative_path):
+            self.prepared = True
+            return module
+
+    class Specialised(PreparedOnlyDuringExecution):
+        _hooking_context_class = HookingContextWithCache
+
+    generic, specialised = PreparedOnlyDuringExecution(), Specialised()
+    pipeline = Pipeline(
+        [
+            MethodStage("generic", generic, coexecution_key="explicit"),
+            MethodStage("specialised", specialised, coexecution_key="explicit"),
+        ]
+    )
+
+    plan = pipeline.plan(TensorDict({"input": torch.ones(2, 10)}, batch_size=[2]))
+
+    assert [run.stages for run in plan.runs] == [("generic",), ("specialised",)]
+    assert not generic.prepared
+    assert not specialised.prepared
 
 
 def test_transform_then_method_with_nested_key(default_test_model):
@@ -273,6 +368,21 @@ def test_context_cleanup_on_method_setup_and_execution_failure(default_test_mode
     execute = Pipeline([TransformStage("explode", lambda td: (_ for _ in ()).throw(RuntimeError("boom")))])
     with pytest.raises(RuntimeError, match="explode.*boom"):
         execute.run(default_test_model, TensorDict({}, batch_size=[]))
+
+
+def test_planned_group_cleanup_on_child_failure(default_test_model):
+    pipeline = Pipeline(
+        [
+            MethodStage("setup", FailingPrepare(), coexecution_key="cleanup-v1"),
+            MethodStage("later", AddOne(), provided_keys=["output"], coexecution_key="cleanup-v1"),
+        ]
+    )
+    assert pipeline.plan().runs[0].coalesced
+
+    with pytest.raises(RuntimeError, match="setup.*later.*hook setup failed"):
+        pipeline.run(default_test_model, TensorDict({"input": torch.ones(2, 10)}, batch_size=[2]))
+
+    assert not hasattr(default_test_model, "pipeline_setup_flag")
 
 
 def test_context_cleanup_handles_interrupts_and_cleanup_errors(default_test_model):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -131,6 +131,39 @@ def test_plan_does_not_prepare_factories_and_isolates_specialised_contexts(defau
     assert not specialised.prepared
 
 
+@pytest.mark.parametrize(
+    "stages",
+    [
+        [TransformStage("transform", lambda td: td)],
+        [MethodStage("unknown", AddOne())],
+        [MethodStage("many-passes", AddOne(), coexecution_key="safe", model_passes=2)],
+        [
+            MethodStage("first", AddOne(), coexecution_key="safe", model_in_keys=["input"]),
+            MethodStage("second", TimesTwo(), coexecution_key="safe", model_in_keys=["different"]),
+        ],
+        [
+            MethodStage("first", AddOne(), coexecution_key="safe", gradient_mode="required"),
+            MethodStage("second", TimesTwo(), coexecution_key="safe", gradient_mode="optional"),
+        ],
+        [
+            MethodStage("first", AddOne(), coexecution_key="safe", provided_keys=["intermediate"]),
+            MethodStage("second", TimesTwo(), coexecution_key="safe", required_keys=["intermediate"]),
+        ],
+        [
+            MethodStage("first", AddOne(), coexecution_key="safe", effects=["writer"]),
+            MethodStage("second", TimesTwo(), coexecution_key="safe", incompatible_effects=["writer"]),
+        ],
+    ],
+)
+def test_coalescing_rejects_each_incomplete_compatibility_contract(stages):
+    assert not Pipeline._can_coalesce(stages)
+
+
+def test_stage_rejects_a_negative_model_pass_declaration():
+    with pytest.raises(ValueError, match="model_passes"):
+        MethodStage("invalid", AddOne(), model_passes=-1)
+
+
 def test_transform_then_method_with_nested_key(default_test_model):
     artifacts = TensorDict({"source": {"x": torch.ones(2, 10)}}, batch_size=[2])
     pipeline = Pipeline(

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -138,6 +138,10 @@ def test_attribution_stage_maps_baseline_and_additional_inputs_and_reports_passe
         },
         batch_size=[2],
     )
+    plan = Pipeline([stage]).plan(artifacts)
+    assert plan.model_passes == 3
+    assert plan.runs[0].gradient_mode == "required"
+    assert plan.runs[0].device_batch_constraints
     result = Pipeline([stage]).run(default_test_model, artifacts)
     assert result.artifacts[("attributions", "values")].shape == (2, 10)
     assert AttributionStage("maximise", ActivationMaximisation(["linear1"], n_steps=4)).capability.model_passes == 4

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -110,6 +110,25 @@ def test_capabilities_are_executable_contracts():
         capability_for_stage("Attribution")
 
 
+def test_attribution_capabilities_preserve_subclass_pass_budgets():
+    class CustomIntegratedGradients(IntegratedGradients):
+        pass
+
+    class CustomActivationMaximisation(ActivationMaximisation):
+        pass
+
+    assert (
+        capability_for_stage(
+            "Attribution", factory=CustomIntegratedGradients(n_steps=2, compute_convergence_delta=True)
+        ).model_passes
+        == 3
+    )
+    assert (
+        capability_for_stage("Attribution", factory=CustomActivationMaximisation(["linear"], n_steps=4)).model_passes
+        == 4
+    )
+
+
 def test_public_stage_factories_build_the_typed_stages():
     assert isinstance(activation_caching_stage("cache", ActivationCaching("0")), ActivationCachingStage)
     assert isinstance(attribution_stage("attr", HookingContextFactory()), AttributionStage)


### PR DESCRIPTION
## Summary

- add deterministic `Pipeline.plan()` preflight with inspectable `ExecutionPlan` and per-run pass budgets
- coalesce adjacent `MethodStage` instances only when an explicit compatibility key and the remaining execution constraints prove a shared `HookGroup` run safe
- split unknown pairs, artifact-dependent stages, and specialised contexts conservatively
- propagate built-in stage pass, gradient, and device/batch capability metadata into plans
- retain the actual plan in `PipelineResult` and document dry-run introspection

## Why

Issue #70 connects the linear pipeline, path-safe `HookGroup`, artifact contracts, and executable stage adapters. Pipelines previously validated artifact availability but did not expose or execute a capability-driven run plan, so every method stage necessarily ran independently and demos could not inspect their pass budget before execution.

## Impact

Callers can inspect a deterministic execution plan before hook registration or model execution. Explicitly compatible hook stages can share one model pass; unknown or specialised combinations continue to run separately. This remains a linear planner and does not introduce a general DAG scheduler.

## Validation

- `uv run pytest -q tests` — 450 passed
- `uv run pre-commit run --all-files` — passed
- `just docs` — passed with the existing AutoAPI cyclic-import warning
- `git diff --check` — passed

Closes #70