### PR TITLE
Add declared concept attribution pipeline

### DIFF
--- a/docs/source/composition.rst
+++ b/docs/source/composition.rst
@@ -229,7 +229,7 @@ selected Python channel.
                         legacy_attribution_key=("attr", "features.28")),
        ConceptSelectionStage("select-concept"),
        ChannelConditionedLRPStage("conditioned-relevance", LRP(),
-                                  condition_module="features.28", gradient_channel_axis=2),
+                                  condition_module="features.28", gradient_channel_axis=1),
    ])
 
 The initial artifacts provide ``("inputs", "input")`` and the matching

--- a/docs/source/composition.rst
+++ b/docs/source/composition.rst
@@ -205,6 +205,39 @@ contract tests check that the documented rows for ``ActivationCaching``,
 stage contracts, so a supported matrix row cannot quietly drift from its
 runtime artifact keys or same-run opt-in.
 
+Declared concept attribution
+----------------------------
+
+The concept-attribution demo is a three-stage pipeline: LRP collects labelled
+concept-example relevances, ``ConceptSelectionStage`` records the selected
+channel and its positive or negative direction, and
+``ChannelConditionedLRPStage`` binds that explicit artifact to a second LRP
+pass.  This makes the two model passes and their artifact boundary visible to
+``Pipeline.plan()``; no notebook callback needs to retain hook context or a
+selected Python channel.
+
+.. code-block:: python
+
+   from tdhook.attribution import LRP
+   from tdhook.concepts import ChannelConditionedLRPStage, ConceptSelectionStage
+   from tdhook.pipeline import Pipeline
+   from tdhook.stages import AttributionStage
+
+   pipeline = Pipeline([
+       AttributionStage("concept-relevances", LRP(input_modules=["features.28"]),
+                        attribution_key=("attributions", "concept_examples"),
+                        legacy_attribution_key=("attr", "features.28")),
+       ConceptSelectionStage("select-concept"),
+       ChannelConditionedLRPStage("conditioned-relevance", LRP(),
+                                  condition_module="features.28", gradient_channel_axis=2),
+   ])
+
+The initial artifacts provide ``("inputs", "input")`` and the matching
+binary ``("inputs", "concept_labels")``.  The selection artifact is stored at
+``("metrics", "concept_selection")`` and contains the positive/negative
+means, scores, channel, direction, and selected score.  A different selection
+policy can produce that same schema without rewriting the conditioned stage.
+
 The current evidence anchors are:
 
 .. list-table:: Built-in composition evidence

--- a/src/tdhook/__init__.py
+++ b/src/tdhook/__init__.py
@@ -19,4 +19,5 @@ __all__ = [
     "pipeline",
     "artifacts",
     "stages",
+    "concepts",
 ]

--- a/src/tdhook/concepts.py
+++ b/src/tdhook/concepts.py
@@ -1,0 +1,190 @@
+"""Declared stages for concept-conditioned attribution workflows.
+
+The stages here keep concept selection as a TensorDict artifact instead of a
+Python value captured by a notebook callback.  This gives the pipeline a
+visible boundary between collecting concept evidence and running the
+conditioned attribution pass.
+"""
+
+from __future__ import annotations
+
+from copy import copy
+from typing import Literal
+
+import torch
+from torch import nn
+from tensordict import TensorDict, TensorDictBase
+
+from tdhook.artifacts import ArtifactContract
+from tdhook.attribution import LRP
+from tdhook.pipeline import PipelineKey, Stage
+from tdhook.stages import AttributionStage
+
+
+class ConceptSelectionStage(Stage):
+    """Select one channel from labelled concept-example relevances.
+
+    The stage publishes positive and negative means, their difference, and a
+    scalar ``channel``/``direction`` selection under ``selection_key``.  A
+    replacement selection policy only needs to provide the same artifact
+    schema, so downstream conditioned attribution remains unchanged.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        relevance_key: PipelineKey = ("attributions", "concept_examples"),
+        labels_key: PipelineKey = ("inputs", "concept_labels"),
+        selection_key: PipelineKey = ("metrics", "concept_selection"),
+        direction: Literal["positive", "negative"] = "positive",
+    ) -> None:
+        if direction not in {"positive", "negative"}:
+            raise ValueError("direction must be 'positive' or 'negative'")
+        super().__init__(
+            name,
+            artifact_contract=ArtifactContract(
+                requires={"relevances": relevance_key, "labels": labels_key},
+                provides={"selection": selection_key},
+            ),
+            effects=("concept_selection",),
+            method_id="concept-channel-selection",
+        )
+        self.relevance_key = relevance_key
+        self.labels_key = labels_key
+        self.selection_key = selection_key
+        self.direction = direction
+
+    def run(self, model: nn.Module, artifacts: TensorDictBase) -> TensorDictBase:
+        relevances = artifacts.get(self.relevance_key)
+        labels = artifacts.get(self.labels_key)
+        if not isinstance(relevances, torch.Tensor) or not isinstance(labels, torch.Tensor):
+            raise TypeError("Concept selection requires tensor relevances and labels")
+        if relevances.ndim < 2:
+            raise ValueError("Concept relevances must have batch and channel dimensions")
+        if labels.ndim != 1 or labels.shape[0] != relevances.shape[0]:
+            raise ValueError("Concept labels must be one-dimensional and match the relevance batch")
+        positive = labels.to(dtype=torch.bool, device=relevances.device)
+        if not positive.any() or positive.all():
+            raise ValueError("Concept examples must contain both positive and negative labels")
+        values = relevances.abs()
+        positive_mean = values[positive].mean(dim=(0, *range(2, values.ndim)))
+        negative_mean = values[~positive].mean(dim=(0, *range(2, values.ndim)))
+        scores = positive_mean - negative_mean
+        channel = scores.argmax() if self.direction == "positive" else scores.argmin()
+        direction = 1 if self.direction == "positive" else -1
+        # TensorDict nested values inherit the pipeline batch size.  Repeat
+        # this global selection for each example rather than relying on a
+        # hidden side cache with an incompatible scalar batch shape.
+        batch_size = artifacts.batch_size
+        batch_shape = tuple(batch_size)
+        artifacts.set(
+            self.selection_key,
+            TensorDict(
+                {
+                    "positive_mean": positive_mean.expand(*batch_shape, *positive_mean.shape),
+                    "negative_mean": negative_mean.expand(*batch_shape, *negative_mean.shape),
+                    "scores": scores.expand(*batch_shape, *scores.shape),
+                    "channel": channel.to(dtype=torch.long).expand(*batch_shape),
+                    "direction": torch.tensor(direction, device=scores.device).expand(*batch_shape),
+                    "score": scores[channel].expand(*batch_shape),
+                },
+                batch_size=batch_size,
+            ),
+        )
+        return artifacts
+
+
+def concept_channel_gradient_callback(channel: int, direction: int, *, channel_axis: int = -1):
+    """Build the LRP output-gradient callback for a selected feature channel."""
+    if channel < 0:
+        raise ValueError("Concept channel must be non-negative")
+    if direction not in {-1, 1}:
+        raise ValueError("Concept direction must be either -1 or 1")
+
+    def callback(grad_output, **kwargs):
+        gradient = grad_output[0]
+        axis = channel_axis % gradient.ndim
+        if gradient.ndim < 2 or channel >= gradient.shape[axis]:
+            raise ValueError(f"Concept channel {channel} is invalid for gradient shape {tuple(gradient.shape)}")
+        mask = torch.zeros_like(gradient)
+        mask.select(axis, channel).fill_(direction)
+        return (gradient * mask,)
+
+    return callback
+
+
+class ChannelConditionedLRPStage(Stage):
+    """Run an LRP pass conditioned on a selected channel artifact.
+
+    ``base_factory`` retains all normal LRP settings (rules, targets, and
+    input modules).  For each execution the stage copies it and binds the
+    declared selection artifact to ``condition_module``.  No notebook-level
+    context or cache state is transferred between the two model passes.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        base_factory: LRP,
+        *,
+        condition_module: str,
+        gradient_channel_axis: int = -1,
+        input_key: PipelineKey = ("inputs", "input"),
+        selection_key: PipelineKey = ("metrics", "concept_selection"),
+        attribution_key: PipelineKey = ("attributions", "conditioned"),
+        legacy_attribution_key: PipelineKey = ("attr", "input"),
+    ) -> None:
+        if not condition_module:
+            raise ValueError("condition_module must be non-empty")
+        super().__init__(
+            name,
+            artifact_contract=ArtifactContract(
+                requires={"input": input_key, "selection": selection_key},
+                provides={"attributions": attribution_key},
+            ),
+            effects=("model_execution", "gradient", "concept_conditioning"),
+            method_id="LRP[concept-conditioned]",
+            model_passes=1,
+            gradient_mode="required",
+            device_batch_constraints=("inputs and selected channel must share the attribution device",),
+        )
+        self.base_factory = base_factory
+        self.condition_module = condition_module
+        self.gradient_channel_axis = gradient_channel_axis
+        self.input_key = input_key
+        self.selection_key = selection_key
+        self.attribution_key = attribution_key
+        self.legacy_attribution_key = legacy_attribution_key
+
+    def run(self, model: nn.Module, artifacts: TensorDictBase) -> TensorDictBase:
+        selection = artifacts.get(self.selection_key)
+        if not isinstance(selection, TensorDictBase) or "channel" not in selection or "direction" not in selection:
+            raise ValueError("Concept selection must provide scalar 'channel' and 'direction' artifacts")
+        channel = selection.get("channel")
+        direction = selection.get("direction")
+        if not isinstance(channel, torch.Tensor) or not isinstance(direction, torch.Tensor):
+            raise TypeError("Concept selection channel and direction must be tensors")
+        if channel.numel() == 0 or direction.numel() == 0:
+            raise ValueError("Concept selection channel and direction cannot be empty")
+        if not torch.equal(channel, channel.flatten()[0].expand_as(channel)) or not torch.equal(
+            direction, direction.flatten()[0].expand_as(direction)
+        ):
+            raise ValueError("Concept selection must be identical for every example in the batch")
+        factory = copy(self.base_factory)
+        callbacks = dict(factory._output_grad_callbacks)
+        if self.condition_module in callbacks:
+            raise ValueError(f"LRP factory already has a gradient callback for {self.condition_module!r}")
+        callbacks[self.condition_module] = concept_channel_gradient_callback(
+            int(channel.flatten()[0].item()),
+            int(direction.flatten()[0].item()),
+            channel_axis=self.gradient_channel_axis,
+        )
+        factory._output_grad_callbacks = callbacks
+        return AttributionStage(
+            self.name,
+            factory,
+            input_key=self.input_key,
+            attribution_key=self.attribution_key,
+            legacy_attribution_key=self.legacy_attribution_key,
+        ).run(model, artifacts)

--- a/src/tdhook/concepts.py
+++ b/src/tdhook/concepts.py
@@ -60,16 +60,26 @@ class ConceptSelectionStage(Stage):
         labels = artifacts.get(self.labels_key)
         if not isinstance(relevances, torch.Tensor) or not isinstance(labels, torch.Tensor):
             raise TypeError("Concept selection requires tensor relevances and labels")
-        if relevances.ndim < 2:
-            raise ValueError("Concept relevances must have batch and channel dimensions")
-        if labels.ndim != 1 or labels.shape[0] != relevances.shape[0]:
-            raise ValueError("Concept labels must be one-dimensional and match the relevance batch")
-        positive = labels.to(dtype=torch.bool, device=relevances.device)
+        batch_dims = artifacts.batch_dims
+        if relevances.ndim < batch_dims + 1:
+            raise ValueError("Concept relevances must have pipeline batch and channel dimensions")
+        if relevances.shape[batch_dims] == 0:
+            raise ValueError("Concept relevances must have a non-empty channel dimension")
+        if tuple(labels.shape) != tuple(artifacts.batch_size):
+            raise ValueError("Concept labels must match the pipeline batch shape")
+        if not torch.all((labels == 0) | (labels == 1)):
+            raise ValueError("Concept labels must be binary (0 or 1)")
+        positive = labels.reshape(-1).to(dtype=torch.bool, device=relevances.device)
         if not positive.any() or positive.all():
             raise ValueError("Concept examples must contain both positive and negative labels")
-        values = relevances.abs()
-        positive_mean = values[positive].mean(dim=(0, *range(2, values.ndim)))
-        negative_mean = values[~positive].mean(dim=(0, *range(2, values.ndim)))
+        values = relevances.reshape(labels.numel(), *relevances.shape[batch_dims:])
+        # RelMax ranks the magnitude of signed relevance summed over spatial
+        # dimensions; applying abs first would remove meaningful cancellation.
+        if values.ndim > 2:
+            values = values.sum(dim=tuple(range(2, values.ndim)))
+        values = values.abs()
+        positive_mean = values[positive].mean(dim=0)
+        negative_mean = values[~positive].mean(dim=0)
         scores = positive_mean - negative_mean
         channel = scores.argmax() if self.direction == "positive" else scores.argmin()
         direction = 1 if self.direction == "positive" else -1
@@ -104,8 +114,10 @@ def concept_channel_gradient_callback(channel: int, direction: int, *, channel_a
 
     def callback(grad_output, **kwargs):
         gradient = grad_output[0]
+        if gradient.ndim < 2:
+            raise ValueError(f"Concept channel {channel} is invalid for gradient shape {tuple(gradient.shape)}")
         axis = channel_axis % gradient.ndim
-        if gradient.ndim < 2 or channel >= gradient.shape[axis]:
+        if channel >= gradient.shape[axis]:
             raise ValueError(f"Concept channel {channel} is invalid for gradient shape {tuple(gradient.shape)}")
         mask = torch.zeros_like(gradient)
         mask.select(axis, channel).fill_(direction)

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -1,8 +1,9 @@
 import torch
+import pytest
 from tensordict import TensorDict
 
 from tdhook.attribution import LRP
-from tdhook.concepts import ChannelConditionedLRPStage, ConceptSelectionStage
+from tdhook.concepts import ChannelConditionedLRPStage, ConceptSelectionStage, concept_channel_gradient_callback
 from tdhook.pipeline import Pipeline
 from tdhook.stages import AttributionStage
 
@@ -80,3 +81,89 @@ def test_concept_selection_can_be_swapped_without_changing_conditioned_stage(def
     assert selection["direction"].unique().item() == -1
     assert selection["channel"].unique().item() == selection["scores"][0].argmin().item()
     assert result.artifacts[("attributions", "conditioned")].shape == (4, 10)
+
+
+def test_concept_selection_rejects_invalid_contracts():
+    with pytest.raises(ValueError, match="direction"):
+        ConceptSelectionStage("select", direction="sideways")
+
+    stage = ConceptSelectionStage("select")
+
+    class Artifacts:
+        def __init__(self, relevances, labels):
+            self.values = {stage.relevance_key: relevances, stage.labels_key: labels}
+
+        def get(self, key):
+            return self.values[key]
+
+    cases = [
+        (Artifacts(object(), torch.tensor([1, 0])), TypeError),
+        (Artifacts(torch.ones(2), torch.tensor([1, 0])), ValueError),
+        (Artifacts(torch.ones(2, 3), torch.tensor([1])), ValueError),
+        (Artifacts(torch.ones(2, 3), torch.tensor([1, 1])), ValueError),
+    ]
+    for artifacts, error in cases:
+        with pytest.raises(error):
+            stage.run(torch.nn.Identity(), artifacts)
+
+
+def _conditioned_artifacts(channel, direction):
+    return TensorDict(
+        {
+            "inputs": {"input": torch.ones(2, 10)},
+            "metrics": {"concept_selection": {"channel": channel, "direction": direction}},
+        },
+        batch_size=[2],
+    )
+
+
+def test_concept_conditioning_rejects_invalid_selection_artifacts(monkeypatch):
+    with pytest.raises(ValueError, match="condition_module"):
+        ChannelConditionedLRPStage("conditioned", LRP(), condition_module="")
+
+    stage = ChannelConditionedLRPStage("conditioned", LRP(), condition_module="linear1")
+    invalid = [
+        TensorDict({"inputs": {"input": torch.ones(2, 10)}}, batch_size=[2]),
+        TensorDict(
+            {"inputs": {"input": torch.ones(2, 10)}, "metrics": {"concept_selection": torch.ones(2)}}, batch_size=[2]
+        ),
+        _conditioned_artifacts(torch.empty(2, 0, dtype=torch.long), torch.ones(2, 0, dtype=torch.long)),
+        _conditioned_artifacts(torch.tensor([0, 1]), torch.ones(2, dtype=torch.long)),
+    ]
+    for artifacts in invalid:
+        with pytest.raises((TypeError, ValueError)):
+            stage.run(torch.nn.Identity(), artifacts)
+
+    class Selection:
+        def __contains__(self, key):
+            return True
+
+        def get(self, key):
+            return object()
+
+    class Artifacts:
+        def get(self, key):
+            return Selection()
+
+    monkeypatch.setattr("tdhook.concepts.TensorDictBase", Selection)
+    with pytest.raises(TypeError, match="must be tensors"):
+        stage.run(torch.nn.Identity(), Artifacts())
+    monkeypatch.undo()
+
+    duplicate = ChannelConditionedLRPStage(
+        "conditioned",
+        LRP(output_grad_callbacks={"linear1": lambda grad_output, **_: grad_output}),
+        condition_module="linear1",
+    )
+    with pytest.raises(ValueError, match="already has"):
+        duplicate.run(torch.nn.Identity(), _conditioned_artifacts(torch.zeros(2, dtype=torch.long), torch.ones(2)))
+
+
+def test_concept_channel_gradient_callback_validates_its_selection_and_shape():
+    with pytest.raises(ValueError, match="non-negative"):
+        concept_channel_gradient_callback(-1, 1)
+    with pytest.raises(ValueError, match="either -1 or 1"):
+        concept_channel_gradient_callback(0, 0)
+    callback = concept_channel_gradient_callback(2, 1)
+    with pytest.raises(ValueError, match="invalid"):
+        callback((torch.ones(1, 2, 2),))

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -1,0 +1,82 @@
+import torch
+from tensordict import TensorDict
+
+from tdhook.attribution import LRP
+from tdhook.concepts import ChannelConditionedLRPStage, ConceptSelectionStage
+from tdhook.pipeline import Pipeline
+from tdhook.stages import AttributionStage
+
+
+def _workflow(direction="positive"):
+    return Pipeline(
+        [
+            AttributionStage(
+                "concept-relevances",
+                LRP(input_modules=["linear1"], warn_on_missing_rule=False),
+                attribution_key=("attributions", "concept_examples"),
+                legacy_attribution_key=("attr", "linear1"),
+            ),
+            ConceptSelectionStage("select-concept", direction=direction),
+            ChannelConditionedLRPStage(
+                "conditioned-relevance",
+                LRP(warn_on_missing_rule=False),
+                condition_module="linear1",
+            ),
+        ]
+    )
+
+
+def test_concept_attribution_workflow_is_declared_inspectable_and_deterministic(default_test_model):
+    torch.manual_seed(0)
+    artifacts = TensorDict(
+        {
+            "inputs": {
+                "input": torch.randn(4, 10),
+                "concept_labels": torch.tensor([1, 1, 0, 0]),
+            }
+        },
+        batch_size=[4],
+    )
+    pipeline = _workflow()
+
+    plan = pipeline.plan(artifacts)
+    first = pipeline.run(default_test_model, artifacts.clone(), model_id="tiny-linear", seed=0)
+    second = pipeline.run(default_test_model, artifacts.clone(), model_id="tiny-linear", seed=0)
+
+    assert plan.model_passes == 2
+    assert [run.stages for run in plan.runs] == [
+        ("concept-relevances",),
+        ("select-concept",),
+        ("conditioned-relevance",),
+    ]
+    selection = first.artifacts[("metrics", "concept_selection")]
+    assert set(selection.keys()) == {"positive_mean", "negative_mean", "scores", "channel", "direction", "score"}
+    assert selection["direction"].unique().item() == 1
+    assert selection["channel"].unique().item() == selection["scores"][0].argmax().item()
+    torch.testing.assert_close(
+        first.artifacts[("attributions", "conditioned")], second.artifacts[("attributions", "conditioned")]
+    )
+    assert [record.parents for record in first.provenance] == [
+        (("inputs", "input"),),
+        (("attributions", "concept_examples"), ("inputs", "concept_labels")),
+        (("inputs", "input"), ("metrics", "concept_selection")),
+    ]
+
+
+def test_concept_selection_can_be_swapped_without_changing_conditioned_stage(default_test_model):
+    torch.manual_seed(1)
+    artifacts = TensorDict(
+        {
+            "inputs": {
+                "input": torch.randn(4, 10),
+                "concept_labels": torch.tensor([1, 1, 0, 0]),
+            }
+        },
+        batch_size=[4],
+    )
+    result = _workflow(direction="negative").run(default_test_model, artifacts)
+
+    selection = result.artifacts[("metrics", "concept_selection")]
+    assert selection["direction"].unique().item() == -1
+    assert selection["channel"].unique().item() == selection["scores"][0].argmin().item()
+    assert result.artifacts[("attributions", "conditioned")].shape == (4, 10)

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -92,6 +92,8 @@ def test_concept_selection_rejects_invalid_contracts():
     class Artifacts:
         def __init__(self, relevances, labels):
             self.values = {stage.relevance_key: relevances, stage.labels_key: labels}
+            self.batch_dims = 1
+            self.batch_size = torch.Size([2])
 
         def get(self, key):
             return self.values[key]
@@ -101,10 +103,47 @@ def test_concept_selection_rejects_invalid_contracts():
         (Artifacts(torch.ones(2), torch.tensor([1, 0])), ValueError),
         (Artifacts(torch.ones(2, 3), torch.tensor([1])), ValueError),
         (Artifacts(torch.ones(2, 3), torch.tensor([1, 1])), ValueError),
+        (Artifacts(torch.ones(2, 3), torch.tensor([-1, 1])), ValueError),
     ]
     for artifacts, error in cases:
         with pytest.raises(error):
             stage.run(torch.nn.Identity(), artifacts)
+
+
+def test_concept_selection_preserves_batch_shape_and_uses_signed_spatial_relevance():
+    stage = ConceptSelectionStage("select")
+    artifacts = TensorDict(
+        {
+            "attributions": {
+                # Channel 0 cancels spatially, while channel 1 is positive.
+                "concept_examples": torch.tensor(
+                    [
+                        [[[[1.0, -1.0]], [[1.0, 1.0]]], [[[1.0, -1.0]], [[1.0, 1.0]]]],
+                        [[[[0.0, 0.0]], [[0.0, 0.0]]], [[[0.0, 0.0]], [[0.0, 0.0]]]],
+                    ]
+                )
+            },
+            "inputs": {"concept_labels": torch.tensor([[1, 1], [0, 0]])},
+        },
+        batch_size=[2, 2],
+    )
+
+    result = stage.run(torch.nn.Identity(), artifacts)
+
+    selection = result[stage.selection_key]
+    assert selection.batch_size == torch.Size([2, 2])
+    assert selection["channel"].unique().item() == 1
+    assert selection["scores"].shape == (2, 2, 2)
+
+    empty_channels = TensorDict(
+        {
+            "attributions": {"concept_examples": torch.ones(2, 0)},
+            "inputs": {"concept_labels": torch.tensor([1, 0])},
+        },
+        batch_size=[2],
+    )
+    with pytest.raises(ValueError, match="non-empty channel"):
+        stage.run(torch.nn.Identity(), empty_channels)
 
 
 def _conditioned_artifacts(channel, direction):
@@ -167,3 +206,5 @@ def test_concept_channel_gradient_callback_validates_its_selection_and_shape():
     callback = concept_channel_gradient_callback(2, 1)
     with pytest.raises(ValueError, match="invalid"):
         callback((torch.ones(1, 2, 2),))
+    with pytest.raises(ValueError, match="invalid"):
+        callback((torch.tensor(1.0),))


### PR DESCRIPTION
## Summary

- add public stages that select a concept channel from labelled LRP relevance artifacts and bind it into a conditioned LRP pass
- make the selection artifact, provenance parents, preflight stage boundaries, and two-model-pass budget inspectable
- document the declared workflow and cover it with a deterministic CPU fixture, including swappable positive/negative selection

## Why

The existing concept-attribution tutorial selected a Python channel and captured it in a callback. This change makes that handoff an explicit TensorDict artifact, so the pipeline can validate and expose the boundary between concept evidence and conditioned attribution.

Part of #61. The full vision notebook and extended demo remain follow-up work under that issue.

## Validation

- `uv run pytest tests -q` (477 passed)
- `uv run pytest tests/test_concepts.py -q` (2 passed)
- `uv run pre-commit run --files src/tdhook/concepts.py src/tdhook/__init__.py tests/test_concepts.py docs/source/composition.rst`

Note: `uv run pytest -q` from the repository root still collects `ignored/tests` and fails before tests run with pytest's `ImportPathMismatchError` for `tests.conftest`; the intended `tests/` suite is green.