### PR TITLE
Add declared intrinsic dimension pipeline

### DIFF
--- a/docs/source/composition.rst
+++ b/docs/source/composition.rst
@@ -256,6 +256,26 @@ The current evidence anchors are:
    * - ``Adapters``
      - ``test_weight_intervention_stage_executes_real_adapters``
 
+Declared intrinsic dimension
+----------------------------
+
+``tdhook.dimension.conditioned_dimension_pipeline`` is the canonical
+activation-to-dimension workflow.  It contains one
+``ActivationCachingStage`` model pass followed by explicit artifact-only
+selection, estimator, and summary stages.  ``channel_conditioned_samples``
+and ``spatial_conditioned_samples`` provide generic reshapes for
+``(samples, channels, ...)`` and ``(samples, channels, height, width)``
+activations; application-specific layer selection and plotting remain outside
+the pipeline.
+
+The estimator stage accepts the existing ``TwoNnDimensionEstimator``,
+``LocalKnnDimensionEstimator``, ``LocalPcaDimensionEstimator``, and
+``CaPcaDimensionEstimator`` without changing their public APIs.  Its samples,
+dimensions, and summary are shape-neutral TensorDict artifacts so condition
+axes do not have to match the original model batch.  The compact CPU fixture
+in ``test_dimension_pipeline.py`` fixes the channel-conditioned TwoNN result
+and verifies both the one-pass plan and estimator interchangeability.
+
 .. csv-table:: Public capability inventory
    :file: _static/composition-capabilities.csv
    :header-rows: 1

--- a/src/tdhook/__init__.py
+++ b/src/tdhook/__init__.py
@@ -20,4 +20,5 @@ __all__ = [
     "artifacts",
     "stages",
     "concepts",
+    "dimension",
 ]

--- a/src/tdhook/dimension.py
+++ b/src/tdhook/dimension.py
@@ -1,0 +1,230 @@
+"""Declared, artifact-only intrinsic-dimension analysis stages.
+
+The stages in this module turn cached activations into estimator inputs without
+encoding a model, board, or plotting convention.  They deliberately run after
+``ActivationCachingStage``: the only model pass belongs to activation capture.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+import torch
+from torch import nn
+from tensordict import TensorDict, TensorDictBase
+from tensordict.nn import TensorDictModuleBase
+from tensordict.tensorclass import NonTensorData
+
+from tdhook.latent import ActivationCaching
+from tdhook.pipeline import Pipeline, PipelineKey, Stage
+from tdhook.stages import ActivationCachingStage
+
+
+def _store_shape_neutral(artifacts: TensorDictBase, key: PipelineKey, value: object) -> None:
+    """Store analysis output without imposing the model batch shape on it."""
+    artifacts.set(key, NonTensorData(value, batch_size=artifacts.batch_size))
+
+
+def _shape_neutral_value(value: object) -> object:
+    return value.data if isinstance(value, NonTensorData) else value
+
+
+def channel_conditioned_samples(activations: torch.Tensor) -> torch.Tensor:
+    """Arrange ``(samples, channels, ...)`` activations as ``(channels, samples, features)``.
+
+    This is useful when each channel is a condition and the remaining trailing
+    dimensions form that condition's feature vector.  It is not tied to a
+    particular model architecture or domain.
+    """
+    if activations.ndim < 3:
+        raise ValueError("Channel-conditioned activations need shape (samples, channels, ...)")
+    return activations.movedim(1, 0).flatten(start_dim=2)
+
+
+def spatial_conditioned_samples(activations: torch.Tensor) -> torch.Tensor:
+    """Arrange ``(samples, channels, height, width)`` activations by spatial location.
+
+    The result has shape ``(height * width, samples, channels)``.  Consumers
+    can use it for image, board, or any other two-dimensional activation grid.
+    """
+    if activations.ndim != 4:
+        raise ValueError("Spatial-conditioned activations need shape (samples, channels, height, width)")
+    samples, channels, height, width = activations.shape
+    return activations.permute(2, 3, 0, 1).reshape(height * width, samples, channels)
+
+
+class ActivationSampleStage(Stage):
+    """Select one cached activation and reshape it into estimator datasets."""
+
+    def __init__(
+        self,
+        name: str,
+        activation_key: PipelineKey,
+        transform: Callable[[torch.Tensor], torch.Tensor],
+        *,
+        cache_key: PipelineKey = ("activations", "cache"),
+        sample_key: PipelineKey = ("activations", "samples"),
+    ) -> None:
+        super().__init__(
+            name,
+            required_keys=[cache_key],
+            provided_keys=[sample_key],
+            effects=["activation_selection"],
+            method_id="ActivationSample",
+        )
+        self.activation_key = activation_key
+        self.transform = transform
+        self.cache_key = cache_key
+        self.sample_key = sample_key
+
+    def run(self, model: nn.Module, artifacts: TensorDictBase) -> TensorDictBase:
+        activations = artifacts.get(self.cache_key).get(self.activation_key)
+        if not isinstance(activations, torch.Tensor):
+            raise TypeError(f"Cached activation {self.activation_key!r} must be a tensor")
+        samples = self.transform(activations)
+        if not isinstance(samples, torch.Tensor):
+            raise TypeError("Activation sample transform must return a tensor")
+        if samples.ndim < 2:
+            raise ValueError("Estimator samples must have shape (..., points, features)")
+        # Condition axes (channels, positions, or layers) need not align with
+        # the model input batch.  NonTensorData preserves the tensor exactly
+        # while retaining TensorDict ownership and provenance.
+        _store_shape_neutral(artifacts, self.sample_key, samples)
+        return artifacts
+
+
+class DimensionEstimationStage(Stage):
+    """Run an existing TensorDict intrinsic-dimension estimator on an artifact.
+
+    ``TwoNnDimensionEstimator``, ``LocalKnnDimensionEstimator``,
+    ``LocalPcaDimensionEstimator``, and ``CaPcaDimensionEstimator`` all use
+    this adapter unchanged.  Their existing ``in_key`` and ``out_key`` remain
+    private to the stage; callers use stable artifact paths instead.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        estimator: TensorDictModuleBase,
+        *,
+        sample_key: PipelineKey = ("activations", "samples"),
+        dimension_key: PipelineKey = ("metrics", "dimension"),
+    ) -> None:
+        in_key = getattr(estimator, "in_key", None)
+        out_key = getattr(estimator, "out_key", None)
+        if not isinstance(in_key, str) or not isinstance(out_key, str):
+            raise TypeError("Dimension estimator stages require string in_key and out_key attributes")
+        super().__init__(
+            name,
+            required_keys=[sample_key],
+            provided_keys=[dimension_key],
+            effects=["dimension_estimation"],
+            method_id=type(estimator).__name__,
+        )
+        self.estimator = estimator
+        self.sample_key = sample_key
+        self.dimension_key = dimension_key
+        self._in_key = in_key
+        self._out_key = out_key
+
+    def run(self, model: nn.Module, artifacts: TensorDictBase) -> TensorDictBase:
+        samples = _shape_neutral_value(artifacts.get(self.sample_key))
+        if not isinstance(samples, torch.Tensor):
+            raise TypeError(f"Estimator samples at {self.sample_key!r} must be a tensor")
+        if samples.ndim < 2:
+            raise ValueError("Estimator samples must have shape (..., points, features)")
+        storage = TensorDict({self._in_key: samples}, batch_size=[])
+        result = self.estimator(storage)
+        _store_shape_neutral(artifacts, self.dimension_key, result.get(self._out_key))
+        return artifacts
+
+
+class DimensionSummaryStage(Stage):
+    """Publish finite-value count, mean, and standard deviation for dimensions."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        dimension_key: PipelineKey = ("metrics", "dimension"),
+        summary_key: PipelineKey = ("metrics", "dimension_summary"),
+        dims: int | Sequence[int] | None = None,
+    ) -> None:
+        super().__init__(
+            name,
+            required_keys=[dimension_key],
+            provided_keys=[summary_key],
+            effects=["dimension_summary"],
+            method_id="DimensionSummary",
+        )
+        self.dimension_key = dimension_key
+        self.summary_key = summary_key
+        self.dims = dims
+
+    def run(self, model: nn.Module, artifacts: TensorDictBase) -> TensorDictBase:
+        dimensions = _shape_neutral_value(artifacts.get(self.dimension_key))
+        if not isinstance(dimensions, torch.Tensor):
+            raise TypeError(f"Dimensions at {self.dimension_key!r} must be a tensor")
+        reduce_dims = (
+            tuple(range(dimensions.ndim))
+            if self.dims is None
+            else ((self.dims,) if isinstance(self.dims, int) else tuple(self.dims))
+        )
+        reduce_dims = tuple(dim if dim >= 0 else dimensions.ndim + dim for dim in reduce_dims)
+        if (
+            not reduce_dims
+            or len(set(reduce_dims)) != len(reduce_dims)
+            or any(dim < 0 or dim >= dimensions.ndim for dim in reduce_dims)
+        ):
+            raise ValueError("Summary dimensions must be unique valid dimensions")
+        finite = torch.isfinite(dimensions)
+        values = torch.where(finite, dimensions, torch.zeros_like(dimensions))
+        count = finite.sum(dim=reduce_dims, keepdim=True)
+        divisor = count.clamp_min(1)
+        mean = values.sum(dim=reduce_dims, keepdim=True) / divisor
+        centered = torch.where(finite, dimensions - mean, torch.zeros_like(dimensions))
+        variance = centered.square().sum(dim=reduce_dims, keepdim=True) / divisor
+        count, mean, variance = (value.squeeze(dim=reduce_dims) for value in (count, mean, variance))
+        summary = TensorDict({"count": count, "mean": mean, "std": variance.sqrt()}, batch_size=[])
+        _store_shape_neutral(artifacts, self.summary_key, summary)
+        return artifacts
+
+
+def conditioned_dimension_pipeline(
+    cache: ActivationCaching,
+    activation_key: PipelineKey,
+    transform: Callable[[torch.Tensor], torch.Tensor],
+    estimator: TensorDictModuleBase,
+    *,
+    input_key: PipelineKey = ("inputs", "input"),
+    cache_key: PipelineKey = ("activations", "cache"),
+    sample_key: PipelineKey = ("activations", "samples"),
+    dimension_key: PipelineKey = ("metrics", "dimension"),
+    summary_key: PipelineKey = ("metrics", "dimension_summary"),
+    summary_dims: int | Sequence[int] | None = None,
+) -> Pipeline:
+    """Build the standard capture, selection, estimation, and summary pipeline."""
+    return Pipeline(
+        [
+            ActivationCachingStage("capture-activations", cache, input_key=input_key, cache_key=cache_key),
+            ActivationSampleStage(
+                "select-samples", activation_key, transform, cache_key=cache_key, sample_key=sample_key
+            ),
+            DimensionEstimationStage(
+                "estimate-dimension", estimator, sample_key=sample_key, dimension_key=dimension_key
+            ),
+            DimensionSummaryStage(
+                "summarize-dimension", dimension_key=dimension_key, summary_key=summary_key, dims=summary_dims
+            ),
+        ]
+    )
+
+
+__all__ = [
+    "ActivationSampleStage",
+    "DimensionEstimationStage",
+    "DimensionSummaryStage",
+    "channel_conditioned_samples",
+    "conditioned_dimension_pipeline",
+    "spatial_conditioned_samples",
+]

--- a/src/tdhook/dimension.py
+++ b/src/tdhook/dimension.py
@@ -172,18 +172,32 @@ class DimensionSummaryStage(Stage):
         )
         reduce_dims = tuple(dim if dim >= 0 else dimensions.ndim + dim for dim in reduce_dims)
         if (
-            not reduce_dims
+            (not reduce_dims and self.dims is not None)
             or len(set(reduce_dims)) != len(reduce_dims)
             or any(dim < 0 or dim >= dimensions.ndim for dim in reduce_dims)
         ):
             raise ValueError("Summary dimensions must be unique valid dimensions")
         finite = torch.isfinite(dimensions)
+        if not reduce_dims:
+            count = finite.to(dtype=torch.long)
+            nan = torch.full_like(dimensions, float("nan"))
+            summary = TensorDict(
+                {
+                    "count": count,
+                    "mean": torch.where(finite, dimensions, nan),
+                    "std": torch.where(finite, torch.zeros_like(dimensions), nan),
+                },
+                batch_size=[],
+            )
+            _store_shape_neutral(artifacts, self.summary_key, summary)
+            return artifacts
         values = torch.where(finite, dimensions, torch.zeros_like(dimensions))
         count = finite.sum(dim=reduce_dims, keepdim=True)
         divisor = count.clamp_min(1)
-        mean = values.sum(dim=reduce_dims, keepdim=True) / divisor
+        nan = torch.full_like(values.sum(dim=reduce_dims, keepdim=True), float("nan"))
+        mean = torch.where(count > 0, values.sum(dim=reduce_dims, keepdim=True) / divisor, nan)
         centered = torch.where(finite, dimensions - mean, torch.zeros_like(dimensions))
-        variance = centered.square().sum(dim=reduce_dims, keepdim=True) / divisor
+        variance = torch.where(count > 0, centered.square().sum(dim=reduce_dims, keepdim=True) / divisor, nan)
         count, mean, variance = (value.squeeze(dim=reduce_dims) for value in (count, mean, variance))
         summary = TensorDict({"count": count, "mean": mean, "std": variance.sqrt()}, batch_size=[])
         _store_shape_neutral(artifacts, self.summary_key, summary)

--- a/tests/test_dimension_pipeline.py
+++ b/tests/test_dimension_pipeline.py
@@ -167,6 +167,24 @@ def test_summary_can_preserve_condition_axes_and_ignores_non_finite_values():
     torch.testing.assert_close(summary["std"], torch.tensor([1.0, (8 / 3) ** 0.5]))
 
 
+def test_summary_handles_scalar_dimensions_and_marks_empty_slices_undefined():
+    scalar = TensorDict({"metrics": {"dimension": NonTensorData(torch.tensor(2.5), batch_size=[])}}, batch_size=[])
+    scalar_summary = Pipeline([DimensionSummaryStage("scalar-summary")]).run(nn.Identity(), scalar)
+    assert scalar_summary.artifacts[("metrics", "dimension_summary")].data["count"].item() == 1
+    torch.testing.assert_close(
+        scalar_summary.artifacts[("metrics", "dimension_summary")].data["mean"], torch.tensor(2.5)
+    )
+
+    empty = TensorDict(
+        {"metrics": {"dimension": NonTensorData(torch.full((2, 3), float("nan")), batch_size=[])}}, batch_size=[]
+    )
+    empty_summary = Pipeline([DimensionSummaryStage("empty-summary", dims=-1)]).run(nn.Identity(), empty)
+    summary = empty_summary.artifacts[("metrics", "dimension_summary")].data
+    torch.testing.assert_close(summary["count"], torch.zeros(2, dtype=torch.long))
+    assert torch.isnan(summary["mean"]).all()
+    assert torch.isnan(summary["std"]).all()
+
+
 def test_summary_rejects_non_tensor_dimensions_and_invalid_reduction_axes():
     artifacts = TensorDict({"metrics": {"dimension": NonTensorData("not-a-tensor", batch_size=[])}}, batch_size=[])
     with pytest.raises(TypeError, match="Dimensions"):
@@ -175,3 +193,5 @@ def test_summary_rejects_non_tensor_dimensions_and_invalid_reduction_axes():
     artifacts.set(("metrics", "dimension"), NonTensorData(torch.ones(2, 2), batch_size=[]))
     with pytest.raises(ValueError, match="unique valid dimensions"):
         DimensionSummaryStage("invalid-axes", dims=(0, 0)).run(nn.Identity(), artifacts)
+    with pytest.raises(ValueError, match="unique valid dimensions"):
+        DimensionSummaryStage("empty-axes", dims=()).run(nn.Identity(), artifacts)

--- a/tests/test_dimension_pipeline.py
+++ b/tests/test_dimension_pipeline.py
@@ -73,6 +73,18 @@ def test_channel_and_spatial_selectors_match_the_notebook_reshapes(activation_fi
     )
 
 
+@pytest.mark.parametrize(
+    ("selector", "activations", "message"),
+    [
+        (channel_conditioned_samples, torch.ones(2, 3), "Channel-conditioned"),
+        (spatial_conditioned_samples, torch.ones(2, 3, 4), "Spatial-conditioned"),
+    ],
+)
+def test_conditioned_selectors_reject_incompatible_activation_shapes(selector, activations, message):
+    with pytest.raises(ValueError, match=message):
+        selector(activations)
+
+
 def test_multiple_cached_layers_can_feed_independent_conditioned_slices(activation_fixture):
     model, inputs = activation_fixture
     first = model(inputs)
@@ -118,6 +130,32 @@ def test_existing_estimators_are_swappable_artifact_only_stages(estimator):
     assert result.plan.model_passes == 0
 
 
+def test_dimension_stages_reject_invalid_artifacts_and_estimator_contracts():
+    artifacts = TensorDict(
+        {"activations": {"cache": {"invalid": NonTensorData("not-a-tensor", batch_size=[])}}}, batch_size=[]
+    )
+    with pytest.raises(TypeError, match="Cached activation"):
+        ActivationSampleStage("invalid-cache", "invalid", lambda value: value).run(nn.Identity(), artifacts)
+
+    tensor_artifacts = TensorDict({"activations": {"cache": {"value": torch.ones(3, 2, 2)}}}, batch_size=[])
+    with pytest.raises(TypeError, match="must return a tensor"):
+        ActivationSampleStage("invalid-transform", "value", lambda value: "not-a-tensor").run(
+            nn.Identity(), tensor_artifacts
+        )
+    with pytest.raises(ValueError, match="points, features"):
+        ActivationSampleStage("invalid-shape", "value", lambda value: value[0, 0]).run(nn.Identity(), tensor_artifacts)
+
+    with pytest.raises(TypeError, match="in_key and out_key"):
+        DimensionEstimationStage("invalid-estimator", nn.Identity())
+
+    samples = TensorDict({"activations": {"samples": NonTensorData("not-a-tensor", batch_size=[])}}, batch_size=[])
+    with pytest.raises(TypeError, match="Estimator samples"):
+        DimensionEstimationStage("invalid-samples", TwoNnDimensionEstimator()).run(nn.Identity(), samples)
+    samples.set(("activations", "samples"), NonTensorData(torch.ones(2), batch_size=[]))
+    with pytest.raises(ValueError, match="points, features"):
+        DimensionEstimationStage("one-dimensional-samples", TwoNnDimensionEstimator()).run(nn.Identity(), samples)
+
+
 def test_summary_can_preserve_condition_axes_and_ignores_non_finite_values():
     dimensions = torch.tensor([[1.0, float("nan"), 3.0], [2.0, 4.0, 6.0]])
     artifacts = TensorDict({"metrics": {"dimension": NonTensorData(dimensions, batch_size=[2])}}, batch_size=[2])
@@ -127,3 +165,13 @@ def test_summary_can_preserve_condition_axes_and_ignores_non_finite_values():
     torch.testing.assert_close(summary["count"], torch.tensor([2, 3]))
     torch.testing.assert_close(summary["mean"], torch.tensor([2.0, 4.0]))
     torch.testing.assert_close(summary["std"], torch.tensor([1.0, (8 / 3) ** 0.5]))
+
+
+def test_summary_rejects_non_tensor_dimensions_and_invalid_reduction_axes():
+    artifacts = TensorDict({"metrics": {"dimension": NonTensorData("not-a-tensor", batch_size=[])}}, batch_size=[])
+    with pytest.raises(TypeError, match="Dimensions"):
+        DimensionSummaryStage("invalid-dimensions").run(nn.Identity(), artifacts)
+
+    artifacts.set(("metrics", "dimension"), NonTensorData(torch.ones(2, 2), batch_size=[]))
+    with pytest.raises(ValueError, match="unique valid dimensions"):
+        DimensionSummaryStage("invalid-axes", dims=(0, 0)).run(nn.Identity(), artifacts)

--- a/tests/test_dimension_pipeline.py
+++ b/tests/test_dimension_pipeline.py
@@ -1,0 +1,129 @@
+import pytest
+import torch
+from torch import nn
+from tensordict import TensorDict
+from tensordict.tensorclass import NonTensorData
+
+from tdhook.dimension import (
+    ActivationSampleStage,
+    DimensionEstimationStage,
+    DimensionSummaryStage,
+    channel_conditioned_samples,
+    conditioned_dimension_pipeline,
+    spatial_conditioned_samples,
+)
+from tdhook.latent import ActivationCaching
+from tdhook.latent.dimension_estimation import (
+    CaPcaDimensionEstimator,
+    LocalKnnDimensionEstimator,
+    LocalPcaDimensionEstimator,
+    TwoNnDimensionEstimator,
+)
+from tdhook.pipeline import Pipeline
+
+
+@pytest.fixture
+def activation_fixture():
+    model = nn.Sequential(nn.Conv2d(3, 4, kernel_size=1, bias=False))
+    with torch.no_grad():
+        model[0].weight.copy_(torch.arange(12, dtype=torch.float32).reshape(4, 3, 1, 1) / 10 + 0.1)
+    inputs = torch.arange(8 * 3 * 2 * 2, dtype=torch.float32).reshape(8, 3, 2, 2) / 20
+    return model, inputs
+
+
+def test_conditioned_dimension_pipeline_has_one_capture_pass_and_frozen_channel_fixture(activation_fixture):
+    model, inputs = activation_fixture
+    pipeline = conditioned_dimension_pipeline(
+        ActivationCaching("0"), "0", channel_conditioned_samples, TwoNnDimensionEstimator()
+    )
+    artifacts = TensorDict({"inputs": {"input": inputs}}, batch_size=[len(inputs)])
+
+    result = pipeline.run(model, artifacts, model_id="frozen-conv", seed=0)
+
+    assert [(run.stages, run.model_passes) for run in result.plan.runs] == [
+        (("capture-activations",), 1),
+        (("select-samples",), 0),
+        (("estimate-dimension",), 0),
+        (("summarize-dimension",), 0),
+    ]
+    torch.testing.assert_close(result.artifacts[("metrics", "dimension")].data, torch.full((4,), 3.0))
+    summary = result.artifacts[("metrics", "dimension_summary")].data
+    assert summary["count"].item() == 4
+    torch.testing.assert_close(summary["mean"], torch.tensor(3.0))
+    torch.testing.assert_close(summary["std"], torch.tensor(0.0))
+    assert [item.parents for item in result.provenance] == [
+        (("inputs", "input"),),
+        (("activations", "cache"),),
+        (("activations", "samples"),),
+        (("metrics", "dimension"),),
+    ]
+
+
+def test_channel_and_spatial_selectors_match_the_notebook_reshapes(activation_fixture):
+    model, inputs = activation_fixture
+    activations = model(inputs)
+
+    assert channel_conditioned_samples(activations).shape == (4, 8, 4)
+    assert spatial_conditioned_samples(activations).shape == (4, 8, 4)
+    torch.testing.assert_close(
+        channel_conditioned_samples(activations), activations.permute(1, 0, 2, 3).reshape(4, 8, 4)
+    )
+    torch.testing.assert_close(
+        spatial_conditioned_samples(activations), activations.permute(2, 3, 0, 1).reshape(4, 8, 4)
+    )
+
+
+def test_multiple_cached_layers_can_feed_independent_conditioned_slices(activation_fixture):
+    model, inputs = activation_fixture
+    first = model(inputs)
+    artifacts = TensorDict({"activations": {"cache": {"first": first, "second": first + 1}}}, batch_size=[len(inputs)])
+    pipeline = Pipeline(
+        [
+            ActivationSampleStage(
+                "first-layer", "first", channel_conditioned_samples, sample_key=("activations", "first")
+            ),
+            ActivationSampleStage(
+                "second-layer", "second", spatial_conditioned_samples, sample_key=("activations", "second")
+            ),
+        ]
+    )
+
+    result = pipeline.run(model, artifacts)
+
+    assert result.plan.model_passes == 0
+    assert result.artifacts[("activations", "first")].data.shape == (4, 8, 4)
+    assert result.artifacts[("activations", "second")].data.shape == (4, 8, 4)
+
+
+@pytest.mark.parametrize(
+    "estimator",
+    [
+        TwoNnDimensionEstimator(),
+        LocalKnnDimensionEstimator(k=2),
+        LocalPcaDimensionEstimator(k=2),
+        CaPcaDimensionEstimator(k=2),
+    ],
+)
+def test_existing_estimators_are_swappable_artifact_only_stages(estimator):
+    samples = torch.tensor(
+        [[[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0], [2.0, 1.0], [1.0, 2.0]]], dtype=torch.float32
+    )
+    artifacts = TensorDict({"activations": {"samples": NonTensorData(samples, batch_size=[2])}}, batch_size=[2])
+    pipeline = Pipeline([DimensionEstimationStage("estimate", estimator)])
+
+    result = pipeline.run(nn.Identity(), artifacts)
+
+    dimensions = result.artifacts[("metrics", "dimension")].data
+    assert dimensions.shape[0] == 1
+    assert result.plan.model_passes == 0
+
+
+def test_summary_can_preserve_condition_axes_and_ignores_non_finite_values():
+    dimensions = torch.tensor([[1.0, float("nan"), 3.0], [2.0, 4.0, 6.0]])
+    artifacts = TensorDict({"metrics": {"dimension": NonTensorData(dimensions, batch_size=[2])}}, batch_size=[2])
+    result = Pipeline([DimensionSummaryStage("summary", dims=-1)]).run(nn.Identity(), artifacts)
+
+    summary = result.artifacts[("metrics", "dimension_summary")].data
+    torch.testing.assert_close(summary["count"], torch.tensor([2, 3]))
+    torch.testing.assert_close(summary["mean"], torch.tensor([2.0, 4.0]))
+    torch.testing.assert_close(summary["std"], torch.tensor([1.0, (8 / 3) ** 0.5]))


### PR DESCRIPTION
## Summary

Adds a generic declared pipeline for conditioned intrinsic-dimension analysis:

- one activation-capture model pass followed by artifact-only selection, estimation, and summary stages;
- reusable channel and spatial conditioning transforms with shape-neutral TensorDict artifacts;
- adapter coverage for TwoNN, local k-NN, local PCA, and CA-PCA estimators, plus frozen CPU fixtures and multi-layer slicing coverage.

The implementation intentionally leaves chess-specific layer selection, plotting, and board rendering downstream of the generic workflow.

## Validation

- `just tests` — 488 passed
- `uv run pre-commit run --files src/tdhook/dimension.py src/tdhook/__init__.py tests/test_dimension_pipeline.py docs/source/composition.rst`
- `just docs`
- `uv lock --check`
- `git diff --check`

Closes #40.