### PR TITLE
Add cross-family composition conformance tests

### DIFF
--- a/docs/source/_static/composition-conformance.csv
+++ b/docs/source/_static/composition-conformance.csv
@@ -1,0 +1,8 @@
+combination,status,test_id,expected_plan,model_passes
+"LRP -> concept selection -> conditioned LRP",supported,test_concept_attribution_workflow_is_declared_inspectable_and_matches_frozen_fixture,"split model -> transform -> model",2
+"ActivationCaching -> conditioned slicing -> TwoNN",supported,test_conditioned_dimension_pipeline_has_one_capture_pass_and_frozen_channel_fixture,"split model -> transform -> transform -> transform",1
+"Probing + Probing",supported,test_real_probing_stages_coexecute_and_publish_independent_results,"coalesced same run",1
+"ActivationCaching + Probing",supported,test_activation_capture_and_probing_follow_declared_conservative_split,"conservative split",2
+"Adapters + ActivationCaching",supported,test_real_intervention_and_activation_read_split_without_state_leaks,"conservative split",2
+"Adapters + Probing failure",supported,test_cross_family_failure_removes_hooks_and_restores_model,"conservative split with cleanup",2
+"Unknown hook pair",unsupported,test_plan_splits_unknown_pairs_and_artifact_boundaries,"conservative split",2

--- a/docs/source/_static/composition-conformance.csv
+++ b/docs/source/_static/composition-conformance.csv
@@ -1,8 +1,8 @@
 combination,status,test_id,expected_plan,model_passes
-"LRP -> concept selection -> conditioned LRP",supported,test_concept_attribution_workflow_is_declared_inspectable_and_matches_frozen_fixture,"split model -> transform -> model",2
-"ActivationCaching -> conditioned slicing -> TwoNN",supported,test_conditioned_dimension_pipeline_has_one_capture_pass_and_frozen_channel_fixture,"split model -> transform -> transform -> transform",1
-"Probing + Probing",supported,test_real_probing_stages_coexecute_and_publish_independent_results,"coalesced same run",1
-"ActivationCaching + Probing",supported,test_activation_capture_and_probing_follow_declared_conservative_split,"conservative split",2
-"Adapters + ActivationCaching",supported,test_real_intervention_and_activation_read_split_without_state_leaks,"conservative split",2
-"Adapters + Probing failure",supported,test_cross_family_failure_removes_hooks_and_restores_model,"conservative split with cleanup",2
-"Unknown hook pair",unsupported,test_plan_splits_unknown_pairs_and_artifact_boundaries,"conservative split",2
+"LRP -> concept selection -> conditioned LRP",supported,test_concept_attribution_workflow_is_declared_inspectable_and_matches_frozen_fixture,"concept-relevances:model:1:separate; select-concept:transform:0:separate; conditioned-relevance:model:1:separate",2
+"ActivationCaching -> conditioned slicing -> TwoNN",supported,test_conditioned_dimension_pipeline_has_one_capture_pass_and_frozen_channel_fixture,"capture-activations:model:1:separate; select-samples:transform:0:separate; estimate-dimension:transform:0:separate; summarize-dimension:transform:0:separate",1
+"Probing + Probing",supported,test_real_probing_stages_coexecute_and_publish_independent_results,"first-probe+second-probe:model:1:coalesced",1
+"ActivationCaching + Probing",supported,test_activation_capture_and_probing_follow_declared_conservative_split,"capture:model:1:separate; probe:model:1:separate",2
+"Adapters + ActivationCaching",supported,test_real_intervention_and_activation_read_split_without_state_leaks,"intervene:model:1:separate; read:model:1:separate",2
+"Adapters + Probing failure",supported,test_cross_family_failure_removes_hooks_and_restores_model,"intervene:model:1:separate; probe:model:1:separate",2
+"Unknown hook pair",unsupported,test_plan_splits_unknown_pairs_and_artifact_boundaries,"first:model:1:separate; second:model:1:separate",2

--- a/docs/source/composition.rst
+++ b/docs/source/composition.rst
@@ -256,6 +256,19 @@ The current evidence anchors are:
    * - ``Adapters``
      - ``test_weight_intervention_stage_executes_real_adapters``
 
+Cross-family conformance
+------------------------
+
+The release conformance matrix names the exact test and preflight decision for
+each supported workflow or method pairing.  A supported multi-stage row does
+not imply same-run support: activation capture with probing, and intervention
+with an activation read, are deliberately split into two model passes.  Unknown
+pairs remain unsupported and are split conservatively.
+
+.. csv-table:: Cross-family composition evidence
+   :file: _static/composition-conformance.csv
+   :header-rows: 1
+
 Declared intrinsic dimension
 ----------------------------
 

--- a/tests/composition_conformance.py
+++ b/tests/composition_conformance.py
@@ -1,0 +1,28 @@
+import csv
+from pathlib import Path
+
+from tdhook.pipeline import ExecutionPlan
+
+
+CONFORMANCE_MATRIX = Path(__file__).parents[1] / "docs" / "source" / "_static" / "composition-conformance.csv"
+
+
+def conformance_rows():
+    with CONFORMANCE_MATRIX.open(newline="") as matrix_file:
+        return list(csv.DictReader(matrix_file))
+
+
+def serialize_plan(plan: ExecutionPlan) -> str:
+    return "; ".join(
+        f"{'+'.join(run.stages)}:{run.kind}:{run.model_passes}:{'coalesced' if run.coalesced else 'separate'}"
+        for run in plan.runs
+    )
+
+
+def assert_conformance(test_id: str, plan: ExecutionPlan, *, status: str) -> None:
+    matches = [row for row in conformance_rows() if row["test_id"] == test_id]
+    assert len(matches) == 1, f"Expected one conformance row for {test_id!r}"
+    row = matches[0]
+    assert row["status"] == status
+    assert int(row["model_passes"]) == plan.model_passes
+    assert row["expected_plan"] == serialize_plan(plan)

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -2,6 +2,7 @@ import torch
 import pytest
 from tensordict import TensorDict
 
+from tests.composition_conformance import assert_conformance
 from tdhook.artifacts import ArtifactRegistry
 from tdhook.attribution import LRP
 from tdhook.concepts import ChannelConditionedLRPStage, ConceptSelectionStage, concept_channel_gradient_callback
@@ -47,6 +48,11 @@ def test_concept_attribution_workflow_is_declared_inspectable_and_matches_frozen
     pipeline.artifact_registry = registry
 
     plan = pipeline.plan(artifacts)
+    assert_conformance(
+        "test_concept_attribution_workflow_is_declared_inspectable_and_matches_frozen_fixture",
+        plan,
+        status="supported",
+    )
     first = pipeline.run(model, artifacts.clone(), model_id="tiny-linear", seed=0)
     second = pipeline.run(model, artifacts.clone(), model_id="tiny-linear", seed=0)
 

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -2,6 +2,7 @@ import torch
 import pytest
 from tensordict import TensorDict
 
+from tdhook.artifacts import ArtifactRegistry
 from tdhook.attribution import LRP
 from tdhook.concepts import ChannelConditionedLRPStage, ConceptSelectionStage, concept_channel_gradient_callback
 from tdhook.pipeline import Pipeline
@@ -27,7 +28,10 @@ def _workflow(direction="positive"):
     )
 
 
-def test_concept_attribution_workflow_is_declared_inspectable_and_deterministic(default_test_model):
+def test_concept_attribution_workflow_is_declared_inspectable_and_matches_frozen_fixture(get_model):
+    model = get_model(seed=42)
+    state_before = {key: value.detach().clone() for key, value in model.state_dict().items()}
+    module_types_before = {name: type(module) for name, module in model.named_modules()}
     torch.manual_seed(0)
     artifacts = TensorDict(
         {
@@ -38,11 +42,13 @@ def test_concept_attribution_workflow_is_declared_inspectable_and_deterministic(
         },
         batch_size=[4],
     )
+    registry = ArtifactRegistry()
     pipeline = _workflow()
+    pipeline.artifact_registry = registry
 
     plan = pipeline.plan(artifacts)
-    first = pipeline.run(default_test_model, artifacts.clone(), model_id="tiny-linear", seed=0)
-    second = pipeline.run(default_test_model, artifacts.clone(), model_id="tiny-linear", seed=0)
+    first = pipeline.run(model, artifacts.clone(), model_id="tiny-linear", seed=0)
+    second = pipeline.run(model, artifacts.clone(), model_id="tiny-linear", seed=0)
 
     assert plan.model_passes == 2
     assert [run.stages for run in plan.runs] == [
@@ -54,9 +60,52 @@ def test_concept_attribution_workflow_is_declared_inspectable_and_deterministic(
     assert set(selection.keys()) == {"positive_mean", "negative_mean", "scores", "channel", "direction", "score"}
     assert selection["direction"].unique().item() == 1
     assert selection["channel"].unique().item() == selection["scores"][0].argmax().item()
+    assert selection["channel"].unique().item() == 8
+    expected = torch.tensor(
+        [
+            [
+                -0.026217487,
+                -0.034608621,
+                0.026935985,
+                -0.020520344,
+                0.030811844,
+                -0.012047096,
+                0.029041190,
+                -0.039444517,
+                -0.025619673,
+                0.015477733,
+            ],
+            [
+                -0.058280926,
+                -0.076934248,
+                0.059878133,
+                -0.045616295,
+                0.068494089,
+                -0.026780445,
+                0.064557955,
+                -0.087684333,
+                -0.056952000,
+                0.034406677,
+            ],
+            [0.0] * 10,
+            [0.0] * 10,
+        ]
+    )
+    torch.testing.assert_close(first.artifacts[("attributions", "conditioned")], expected)
     torch.testing.assert_close(
         first.artifacts[("attributions", "conditioned")], second.artifacts[("attributions", "conditioned")]
     )
+    assert first.artifacts[("attributions", "concept_examples")].shape == (4, 20)
+    assert first.artifacts[("attributions", "conditioned")].shape == artifacts[("inputs", "input")].shape
+    assert first.artifacts[("attributions", "conditioned")].device == artifacts[("inputs", "input")].device
+    registry.require_fresh(("metrics", "concept_selection"), generation=2)
+    registry.require_fresh(("attributions", "conditioned"), generation=2)
+    with pytest.raises(ValueError, match="already owned"):
+        registry.claim(("attributions", "conditioned"), "another-stage", generation=2)
+    assert {name: type(module) for name, module in model.named_modules()} == module_types_before
+    assert all(parameter.grad is None for parameter in model.parameters())
+    for key, value in model.state_dict().items():
+        torch.testing.assert_close(value, state_before[key])
     assert [record.parents for record in first.provenance] == [
         (("inputs", "input"),),
         (("attributions", "concept_examples"), ("inputs", "concept_labels")),

--- a/tests/test_cross_family_composition.py
+++ b/tests/test_cross_family_composition.py
@@ -1,0 +1,181 @@
+import csv
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+
+from tdhook.contexts import HookingContextFactory
+from tdhook.latent import ActivationCaching, Probing
+from tdhook.pipeline import MethodStage, Pipeline
+from tdhook.stages import ActivationCachingStage, ProbingStage, WeightInterventionStage
+from tdhook.weights import Adapters
+
+
+CONFORMANCE_MATRIX = Path(__file__).parents[1] / "docs" / "source" / "_static" / "composition-conformance.csv"
+
+
+def _hook_count(model):
+    hook_attributes = ("_forward_hooks", "_forward_pre_hooks", "_backward_hooks", "_backward_pre_hooks")
+    return sum(len(getattr(module, attribute)) for module in model.modules() for attribute in hook_attributes)
+
+
+def test_activation_capture_and_probing_follow_declared_conservative_split(default_test_model):
+    class RecordingProbe:
+        def __init__(self):
+            self.values = []
+
+        def step(self, data, **kwargs):
+            self.values.append(data.detach().clone())
+
+    probe = RecordingProbe()
+    probe_results = object()
+    cache_factory = ActivationCaching("linear1")
+    pipeline = Pipeline(
+        [
+            ActivationCachingStage("capture", cache_factory),
+            ProbingStage("probe", Probing("linear2", lambda *_: probe), probe_results),
+        ]
+    )
+    inputs = torch.ones(2, 10)
+    artifacts = TensorDict({"inputs": {"input": inputs}}, batch_size=[2])
+    hooks_before = _hook_count(default_test_model)
+
+    plan = pipeline.plan(artifacts)
+    result = pipeline.run(default_test_model, artifacts, model_id="tiny-linear")
+
+    assert [(run.stages, run.model_passes, run.coalesced) for run in plan.runs] == [
+        (("capture",), 1, False),
+        (("probe",), 1, False),
+    ]
+    assert plan.model_passes == 2
+    assert result.artifacts[("activations", "cache")]["linear1"].shape == (2, 20)
+    assert result.artifacts[("activations", "cache")]["linear1"].device == inputs.device
+    assert result.artifacts[("probes", "results")] is probe_results
+    assert len(probe.values) == 1 and probe.values[0].shape == (2, 20)
+    assert [record.parents for record in result.provenance] == [
+        (("inputs", "input"),),
+        (("inputs", "input"),),
+    ]
+    assert cache_factory._hooking_context_kwargs["cache"] is None
+    assert _hook_count(default_test_model) == hooks_before
+
+
+def test_real_intervention_and_activation_read_split_without_state_leaks(default_test_model):
+    inputs = torch.ones(2, 10)
+    expected = default_test_model(inputs)
+    state_before = {key: value.detach().clone() for key, value in default_test_model.state_dict().items()}
+    hooks_before = _hook_count(default_test_model)
+    pipeline = Pipeline(
+        [
+            WeightInterventionStage("intervene", Adapters({"identity": (nn.Identity(), "linear1", "linear1")})),
+            ActivationCachingStage("read", ActivationCaching("linear2")),
+        ]
+    )
+    artifacts = TensorDict({"inputs": {"input": inputs}}, batch_size=[2])
+
+    plan = pipeline.plan(artifacts)
+    result = pipeline.run(default_test_model, artifacts)
+
+    assert [(run.stages, run.model_passes, run.coalesced) for run in plan.runs] == [
+        (("intervene",), 1, False),
+        (("read",), 1, False),
+    ]
+    assert plan.model_passes == 2
+    torch.testing.assert_close(result.artifacts[("outputs", "model")], expected)
+    assert result.artifacts[("activations", "cache")]["linear2"].shape == (2, 20)
+    assert set(default_test_model.state_dict()) == set(state_before)
+    for key, value in default_test_model.state_dict().items():
+        torch.testing.assert_close(value, state_before[key])
+    assert _hook_count(default_test_model) == hooks_before
+    assert not any("adapter" in name for name, _ in default_test_model.named_modules())
+
+
+@pytest.mark.parametrize("wrap_tensordict", [False, True], ids=["pytorch", "tensordict-module"])
+def test_composed_models_support_nested_multiple_input_output_keys(wrap_tensordict):
+    class Pair(nn.Module):
+        def forward(self, left, right):
+            return left + right, left - right
+
+    in_keys = [("inputs", "left"), ("inputs", "right")]
+    out_keys = [("outputs", "sum"), ("outputs", "difference")]
+    model = Pair()
+    if wrap_tensordict:
+        model = TensorDictModule(model, in_keys=in_keys, out_keys=out_keys)
+    pipeline = Pipeline(
+        [
+            MethodStage(
+                "pair",
+                HookingContextFactory(),
+                required_keys=in_keys,
+                provided_keys=out_keys,
+                model_in_keys=in_keys,
+                model_out_keys=out_keys,
+            )
+        ]
+    )
+    left = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    right = torch.full((2, 3), 2.0)
+
+    result = pipeline.run(
+        model,
+        TensorDict({"inputs": {"left": left, "right": right}}, batch_size=[2]),
+    )
+
+    assert result.plan.model_passes == 1
+    torch.testing.assert_close(result.artifacts[("outputs", "sum")], left + right)
+    torch.testing.assert_close(result.artifacts[("outputs", "difference")], left - right)
+    assert _hook_count(model) == 0
+
+
+def test_cross_family_failure_removes_hooks_and_restores_model(default_test_model):
+    class ExplodingProbe:
+        def step(self, data, **kwargs):
+            raise ValueError("probe failed")
+
+    state_before = {key: value.detach().clone() for key, value in default_test_model.state_dict().items()}
+    hooks_before = _hook_count(default_test_model)
+    pipeline = Pipeline(
+        [
+            WeightInterventionStage("intervene", Adapters({"identity": (nn.Identity(), "linear1", "linear1")})),
+            ProbingStage("probe", Probing("linear2", lambda *_: ExplodingProbe()), object()),
+        ]
+    )
+    artifacts = TensorDict({"inputs": {"input": torch.ones(2, 10)}}, batch_size=[2])
+
+    plan = pipeline.plan(artifacts)
+    assert [(run.stages, run.model_passes, run.coalesced) for run in plan.runs] == [
+        (("intervene",), 1, False),
+        (("probe",), 1, False),
+    ]
+
+    with pytest.raises(RuntimeError, match="probe.*probe failed"):
+        pipeline.run(default_test_model, artifacts)
+
+    for key, value in default_test_model.state_dict().items():
+        torch.testing.assert_close(value, state_before[key])
+    assert _hook_count(default_test_model) == hooks_before
+    assert not any("adapter" in name for name, _ in default_test_model.named_modules())
+
+
+def test_supported_conformance_rows_name_a_test_and_expected_plan():
+    with CONFORMANCE_MATRIX.open(newline="") as matrix_file:
+        rows = list(csv.DictReader(matrix_file))
+
+    assert {row["status"] for row in rows} <= {"supported", "unsupported"}
+    supported = [row for row in rows if row["status"] == "supported"]
+    unsupported = [row for row in rows if row["status"] == "unsupported"]
+    assert supported
+    assert unsupported
+    assert all(row["test_id"].startswith("test_") for row in supported)
+    assert all(row["expected_plan"] and row["model_passes"].isdigit() for row in supported)
+    source = Path(__file__).read_text()
+    source += (Path(__file__).with_name("test_concepts.py")).read_text()
+    source += (Path(__file__).with_name("test_dimension_pipeline.py")).read_text()
+    source += (Path(__file__).with_name("test_pipeline.py")).read_text()
+    source += (Path(__file__).with_name("test_stages.py")).read_text()
+    for row in rows:
+        assert f"def {row['test_id']}" in source, row["combination"]
+    assert all("split" in row["expected_plan"] for row in unsupported)

--- a/tests/test_cross_family_composition.py
+++ b/tests/test_cross_family_composition.py
@@ -1,4 +1,3 @@
-import csv
 from pathlib import Path
 
 import pytest
@@ -7,14 +6,12 @@ from torch import nn
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
 
+from tests.composition_conformance import assert_conformance, conformance_rows
 from tdhook.contexts import HookingContextFactory
 from tdhook.latent import ActivationCaching, Probing
 from tdhook.pipeline import MethodStage, Pipeline
 from tdhook.stages import ActivationCachingStage, ProbingStage, WeightInterventionStage
 from tdhook.weights import Adapters
-
-
-CONFORMANCE_MATRIX = Path(__file__).parents[1] / "docs" / "source" / "_static" / "composition-conformance.csv"
 
 
 def _hook_count(model):
@@ -44,6 +41,9 @@ def test_activation_capture_and_probing_follow_declared_conservative_split(defau
     hooks_before = _hook_count(default_test_model)
 
     plan = pipeline.plan(artifacts)
+    assert_conformance(
+        "test_activation_capture_and_probing_follow_declared_conservative_split", plan, status="supported"
+    )
     result = pipeline.run(default_test_model, artifacts, model_id="tiny-linear")
 
     assert [(run.stages, run.model_passes, run.coalesced) for run in plan.runs] == [
@@ -77,6 +77,9 @@ def test_real_intervention_and_activation_read_split_without_state_leaks(default
     artifacts = TensorDict({"inputs": {"input": inputs}}, batch_size=[2])
 
     plan = pipeline.plan(artifacts)
+    assert_conformance(
+        "test_real_intervention_and_activation_read_split_without_state_leaks", plan, status="supported"
+    )
     result = pipeline.run(default_test_model, artifacts)
 
     assert [(run.stages, run.model_passes, run.coalesced) for run in plan.runs] == [
@@ -146,6 +149,7 @@ def test_cross_family_failure_removes_hooks_and_restores_model(default_test_mode
     artifacts = TensorDict({"inputs": {"input": torch.ones(2, 10)}}, batch_size=[2])
 
     plan = pipeline.plan(artifacts)
+    assert_conformance("test_cross_family_failure_removes_hooks_and_restores_model", plan, status="supported")
     assert [(run.stages, run.model_passes, run.coalesced) for run in plan.runs] == [
         (("intervene",), 1, False),
         (("probe",), 1, False),
@@ -161,9 +165,7 @@ def test_cross_family_failure_removes_hooks_and_restores_model(default_test_mode
 
 
 def test_supported_conformance_rows_name_a_test_and_expected_plan():
-    with CONFORMANCE_MATRIX.open(newline="") as matrix_file:
-        rows = list(csv.DictReader(matrix_file))
-
+    rows = conformance_rows()
     assert {row["status"] for row in rows} <= {"supported", "unsupported"}
     supported = [row for row in rows if row["status"] == "supported"]
     unsupported = [row for row in rows if row["status"] == "unsupported"]
@@ -178,4 +180,4 @@ def test_supported_conformance_rows_name_a_test_and_expected_plan():
     source += (Path(__file__).with_name("test_stages.py")).read_text()
     for row in rows:
         assert f"def {row['test_id']}" in source, row["combination"]
-    assert all("split" in row["expected_plan"] for row in unsupported)
+        assert f'"{row["test_id"]}"' in source, row["combination"]

--- a/tests/test_dimension_pipeline.py
+++ b/tests/test_dimension_pipeline.py
@@ -4,6 +4,7 @@ from torch import nn
 from tensordict import TensorDict
 from tensordict.tensorclass import NonTensorData
 
+from tdhook.artifacts import ArtifactRegistry
 from tdhook.dimension import (
     ActivationSampleStage,
     DimensionEstimationStage,
@@ -33,9 +34,12 @@ def activation_fixture():
 
 def test_conditioned_dimension_pipeline_has_one_capture_pass_and_frozen_channel_fixture(activation_fixture):
     model, inputs = activation_fixture
+    hooks_before = sum(len(module._forward_hooks) + len(module._forward_pre_hooks) for module in model.modules())
+    registry = ArtifactRegistry()
     pipeline = conditioned_dimension_pipeline(
         ActivationCaching("0"), "0", channel_conditioned_samples, TwoNnDimensionEstimator()
     )
+    pipeline.artifact_registry = registry
     artifacts = TensorDict({"inputs": {"input": inputs}}, batch_size=[len(inputs)])
 
     result = pipeline.run(model, artifacts, model_id="frozen-conv", seed=0)
@@ -47,6 +51,9 @@ def test_conditioned_dimension_pipeline_has_one_capture_pass_and_frozen_channel_
         (("summarize-dimension",), 0),
     ]
     torch.testing.assert_close(result.artifacts[("metrics", "dimension")].data, torch.full((4,), 3.0))
+    assert result.artifacts[("activations", "cache")]["0"].shape == (8, 4, 2, 2)
+    assert result.artifacts[("activations", "samples")].data.shape == (4, 8, 4)
+    assert result.artifacts[("metrics", "dimension")].data.device == inputs.device
     summary = result.artifacts[("metrics", "dimension_summary")].data
     assert summary["count"].item() == 4
     torch.testing.assert_close(summary["mean"], torch.tensor(3.0))
@@ -57,6 +64,40 @@ def test_conditioned_dimension_pipeline_has_one_capture_pass_and_frozen_channel_
         (("activations", "samples"),),
         (("metrics", "dimension"),),
     ]
+    for key in (
+        ("activations", "cache"),
+        ("activations", "samples"),
+        ("metrics", "dimension"),
+        ("metrics", "dimension_summary"),
+    ):
+        registry.require_fresh(key, generation=1)
+    with pytest.raises(ValueError, match="already owned"):
+        registry.claim(("metrics", "dimension"), "another-stage", generation=1)
+    assert all(parameter.grad is None for parameter in model.parameters())
+    assert (
+        sum(len(module._forward_hooks) + len(module._forward_pre_hooks) for module in model.modules()) == hooks_before
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA parity is optional")
+def test_conditioned_dimension_pipeline_matches_cpu_on_cuda(activation_fixture):
+    cpu_model, cpu_inputs = activation_fixture
+    cpu_result = conditioned_dimension_pipeline(
+        ActivationCaching("0"), "0", channel_conditioned_samples, TwoNnDimensionEstimator()
+    ).run(cpu_model, TensorDict({"inputs": {"input": cpu_inputs}}, batch_size=[len(cpu_inputs)]))
+
+    cuda_model = cpu_model.to("cuda")
+    cuda_inputs = cpu_inputs.to("cuda")
+    cuda_result = conditioned_dimension_pipeline(
+        ActivationCaching("0"), "0", channel_conditioned_samples, TwoNnDimensionEstimator()
+    ).run(cuda_model, TensorDict({"inputs": {"input": cuda_inputs}}, batch_size=[len(cuda_inputs)]))
+
+    assert cuda_result.plan.model_passes == 1
+    assert cuda_result.artifacts[("metrics", "dimension")].data.device.type == "cuda"
+    torch.testing.assert_close(
+        cuda_result.artifacts[("metrics", "dimension")].data.cpu(),
+        cpu_result.artifacts[("metrics", "dimension")].data,
+    )
 
 
 def test_channel_and_spatial_selectors_match_the_notebook_reshapes(activation_fixture):

--- a/tests/test_dimension_pipeline.py
+++ b/tests/test_dimension_pipeline.py
@@ -4,6 +4,7 @@ from torch import nn
 from tensordict import TensorDict
 from tensordict.tensorclass import NonTensorData
 
+from tests.composition_conformance import assert_conformance
 from tdhook.artifacts import ArtifactRegistry
 from tdhook.dimension import (
     ActivationSampleStage,
@@ -43,6 +44,11 @@ def test_conditioned_dimension_pipeline_has_one_capture_pass_and_frozen_channel_
     artifacts = TensorDict({"inputs": {"input": inputs}}, batch_size=[len(inputs)])
 
     result = pipeline.run(model, artifacts, model_id="frozen-conv", seed=0)
+    assert_conformance(
+        "test_conditioned_dimension_pipeline_has_one_capture_pass_and_frozen_channel_fixture",
+        result.plan,
+        status="supported",
+    )
 
     assert [(run.stages, run.model_passes) for run in result.plan.runs] == [
         (("capture-activations",), 1),

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -4,6 +4,7 @@ from torch import nn
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
 
+from tests.composition_conformance import assert_conformance
 from tdhook.attribution import ActivationMaximisation
 from tdhook.contexts import HookingContextFactory, HookingContextWithCache
 from tdhook.artifacts import ArtifactAdapter, ArtifactContract
@@ -100,6 +101,7 @@ def test_plan_splits_unknown_pairs_and_artifact_boundaries(default_test_model):
     )
 
     plan = pipeline.plan(TensorDict({"input": torch.ones(2, 10)}, batch_size=[2]))
+    assert_conformance("test_plan_splits_unknown_pairs_and_artifact_boundaries", plan, status="unsupported")
 
     assert [run.stages for run in plan.runs] == [("first",), ("second",)]
     assert plan.model_passes == 2

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -4,6 +4,7 @@ from torch import nn
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
 
+from tests.composition_conformance import assert_conformance
 from tdhook.artifacts import ArtifactRegistry
 from tdhook.attribution import ActivationMaximisation, IntegratedGradients, LRP
 from tdhook.latent import ActivationCaching, Probing
@@ -90,6 +91,7 @@ def test_real_probing_stages_coexecute_and_publish_independent_results(default_t
     artifacts = TensorDict({"inputs": {"input": torch.ones(2, 10)}}, batch_size=[2])
 
     plan = pipeline.plan(artifacts)
+    assert_conformance("test_real_probing_stages_coexecute_and_publish_independent_results", plan, status="supported")
     result = pipeline.run(default_test_model, artifacts)
     handle.remove()
 


### PR DESCRIPTION
## What changed

- add a documented cross-family conformance matrix that names the concrete test and expected planner decision for each supported pairing
- freeze the compact concept-attribution fixture and assert its two-pass plan, artifact shape/device/ownership/freshness, provenance, and model cleanup
- harden the conditioned-dimension demo with artifact lifecycle checks and optional CPU/CUDA parity
- cover activation capture + probing and adapter intervention + activation reads with explicit conservative two-pass plans
- cover plain PyTorch and TensorDictModule models with nested, multiple input/output keys
- cover cross-family failure cleanup for hooks, model state, and temporary adapter modules

## Why

Issue #62 tracks the remaining evidence gaps after the planner and the two accepted workflows landed. This PR adds focused conformance evidence without introducing new planner abstractions or duplicating the lifecycle tests already merged in #73.

## Impact

Supported cross-family workflows now have executable, offline evidence for their exact preflight decisions and pass budgets. Pairings that are not declared safe for same-run execution remain explicitly split.

## Validation

- `uv run pre-commit run --all-files`
- `just tests` — 500 passed, 1 optional CUDA test skipped; 98.05% coverage
- `just docs` — succeeded with the existing AutoAPI cyclic-import warning
- focused post-commit suite — 25 passed, 1 optional CUDA test skipped

Closes #62