### PR TITLE
Add declared pipeline tutorials

### DIFF
--- a/docs/source/composition.rst
+++ b/docs/source/composition.rst
@@ -289,6 +289,25 @@ axes do not have to match the original model batch.  The compact CPU fixture
 in ``test_dimension_pipeline.py`` fixes the channel-conditioned TwoNN result
 and verifies both the one-pass plan and estimator interchangeability.
 
+Tutorial migration
+------------------
+
+The canonical tutorial paths are the offline :doc:`declared-pipelines`
+walkthrough and its executable notebook.  They use public stage classes and
+read all hand-offs from named artifacts: concept selection from
+``("metrics", "concept_selection")``; conditioned relevance from
+``("attributions", "conditioned")``; and dimension samples, estimates, and
+summaries from the ``("activations", ...)`` and ``("metrics", ...)``
+namespaces.  Natural-image and chess board rendering are presentation
+transforms that consume those artifacts; they are not a reason to retain
+notebook callbacks or cache-to-dictionary orchestration.
+
+The public API inventory covers 25+ exported method classes and documented
+method variants.  That count describes available operations, not a claim that
+every pair can share a model run.  The conformance matrix records the exact
+test identifier, preflight decision, and expected pass budget for every
+supported workflow; unsupported or unknown pairs split conservatively.
+
 .. csv-table:: Public capability inventory
    :file: _static/composition-capabilities.csv
    :header-rows: 1

--- a/docs/source/declared-pipelines.rst
+++ b/docs/source/declared-pipelines.rst
@@ -1,0 +1,103 @@
+Declared pipelines: an offline walkthrough
+===========================================
+
+This compact tutorial is the canonical starting point for TDHook's declared
+workflow API.  It uses a deterministic local model and tensors only: no model
+download, checkpoint, or dataset is required.  The accompanying
+``declared-pipelines`` notebook contains the same executable examples.
+
+Every pipeline has two phases.  :meth:`~tdhook.pipeline.Pipeline.plan` is a
+side-effect-free preflight that exposes model-pass cost and stage boundaries;
+:meth:`~tdhook.pipeline.Pipeline.run` then produces named artifacts and their
+provenance.  A split is intentional: TDHook only co-executes stages with an
+explicit compatible capability contract.
+
+Minimal concept-conditioned attribution
+---------------------------------------
+
+The declared concept workflow has exactly two model passes.  The first LRP
+stage records relevance for labelled concept examples, the artifact-only
+selection stage chooses a channel, and the second LRP stage consumes that
+selection artifact.  No callback, prepared hook context, or activation cache
+is transferred by the notebook.
+
+.. code-block:: python
+
+   from tensordict import TensorDict
+   from tdhook.attribution import LRP
+   from tdhook.concepts import ChannelConditionedLRPStage, ConceptSelectionStage
+   from tdhook.pipeline import Pipeline
+   from tdhook.stages import AttributionStage
+
+   concept_pipeline = Pipeline([
+       AttributionStage(
+           "concept-relevances", LRP(input_modules=["features"], warn_on_missing_rule=False),
+           attribution_key=("attributions", "concept_examples"),
+           legacy_attribution_key=("attr", "features"),
+       ),
+       ConceptSelectionStage("select-concept"),
+       ChannelConditionedLRPStage(
+           "conditioned-relevance", LRP(warn_on_missing_rule=False), condition_module="features",
+       ),
+   ])
+   artifacts = TensorDict(
+       {"inputs": {"input": examples, "concept_labels": labels}}, batch_size=[len(examples)]
+   )
+   plan = concept_pipeline.plan(artifacts)
+   assert plan.model_passes == 2
+   print([(run.stages, run.model_passes) for run in plan.runs])
+   result = concept_pipeline.run(model, artifacts, model_id="offline-tiny", seed=0)
+
+The selected concept is at ``("metrics", "concept_selection")`` and the
+conditioned input relevance is at ``("attributions", "conditioned")``.  The
+result's ``provenance`` records that the selection depends on the concept
+relevances and labels, while the conditioned attribution depends on the input
+and selection artifact.  This is the workflow exercised by
+``test_concept_attribution_workflow_is_declared_inspectable_and_matches_frozen_fixture``
+in the conformance matrix.
+
+Conditioned intrinsic dimension
+-------------------------------
+
+Use :func:`tdhook.dimension.conditioned_dimension_pipeline` when a captured
+activation should become a conditioned estimator input.  Its only model pass
+is activation capture; sample selection, estimation, and summary are
+artifact-only stages.  For image or board features, use
+:func:`tdhook.dimension.channel_conditioned_samples` for ``(sample, channel,
+...)`` activations and keep rendering or plotting downstream.
+
+.. code-block:: python
+
+   from tdhook.dimension import channel_conditioned_samples, conditioned_dimension_pipeline
+   from tdhook.latent import ActivationCaching
+   from tdhook.latent.dimension_estimation import TwoNnDimensionEstimator
+
+   dimension_pipeline = conditioned_dimension_pipeline(
+       ActivationCaching("features"),
+       "features",
+       channel_conditioned_samples,
+       TwoNnDimensionEstimator(),
+   )
+   artifacts = TensorDict({"inputs": {"input": examples}}, batch_size=[len(examples)])
+   plan = dimension_pipeline.plan(artifacts)
+   assert plan.model_passes == 1
+   print([(run.stages, run.model_passes) for run in plan.runs])
+   result = dimension_pipeline.run(model, artifacts, model_id="offline-tiny", seed=0)
+
+The result publishes the real cache at ``("activations", "cache")``, shaped
+samples at ``("activations", "samples")``, estimates at ``("metrics",
+"dimension")``, and finite-value summary at ``("metrics", "dimension_summary")``.
+These latter three can have a condition axis unrelated to the original batch,
+so TDHook preserves them as shape-neutral named artifacts instead of copying
+them to Python dictionaries.
+
+Conformance and scope
+---------------------
+
+The :doc:`composition` page is the source of truth for supported combinations.
+In particular, a pipeline does not promise universal same-run execution:
+unknown or incompatible pairs split conservatively before hooks are installed.
+The phrase ``25+ methods`` describes the public API inventory's exported
+classes and documented method variants; it is not a claim that every pair of
+those methods co-executes.  The capability and conformance matrices name the
+tested combinations, expected plans, and pass budgets.

--- a/docs/source/declared-pipelines.rst
+++ b/docs/source/declared-pipelines.rst
@@ -12,6 +12,52 @@ side-effect-free preflight that exposes model-pass cost and stage boundaries;
 provenance.  A split is intentional: TDHook only co-executes stages with an
 explicit compatible capability contract.
 
+Offline fixture
+---------------
+
+Run this setup once before either workflow.  The concept model exposes the
+``linear1`` feature selected by LRP; the dimension model exposes a four-
+dimensional ``features`` activation for channel-conditioned sampling.
+
+.. code-block:: python
+
+   import torch
+   from torch import nn
+
+   torch.manual_seed(0)
+
+   class TinyConceptModel(nn.Module):
+       def __init__(self):
+           super().__init__()
+           self.linear1 = nn.Linear(10, 10)
+           self.relu = nn.ReLU()
+           self.linear2 = nn.Linear(10, 2)
+
+       def forward(self, input):
+           return self.linear2(self.relu(self.linear1(input)))
+
+   class FeatureMap(nn.Module):
+       def __init__(self):
+           super().__init__()
+           self.linear = nn.Linear(10, 12)
+
+       def forward(self, input):
+           return self.linear(input).relu().reshape(-1, 3, 2, 2)
+
+   class TinyFeatureModel(nn.Module):
+       def __init__(self):
+           super().__init__()
+           self.features = FeatureMap()
+           self.head = nn.Linear(12, 2)
+
+       def forward(self, input):
+           return self.head(self.features(input).flatten(1))
+
+   concept_model = TinyConceptModel().eval()
+   dimension_model = TinyFeatureModel().eval()
+   examples = torch.randn(6, 10)
+   labels = torch.tensor([1, 1, 1, 0, 0, 0])
+
 Minimal concept-conditioned attribution
 ---------------------------------------
 
@@ -46,7 +92,7 @@ is transferred by the notebook.
    plan = concept_pipeline.plan(artifacts)
    assert plan.model_passes == 2
    print([(run.stages, run.model_passes) for run in plan.runs])
-   result = concept_pipeline.run(model, artifacts, model_id="offline-tiny", seed=0)
+   result = concept_pipeline.run(concept_model, artifacts, model_id="offline-tiny", seed=0)
 
 The selected concept is at ``("metrics", "concept_selection")`` and the
 conditioned input relevance is at ``("attributions", "conditioned")``.  The
@@ -82,7 +128,7 @@ artifact-only stages.  For image or board features, use
    plan = dimension_pipeline.plan(artifacts)
    assert plan.model_passes == 1
    print([(run.stages, run.model_passes) for run in plan.runs])
-   result = dimension_pipeline.run(model, artifacts, model_id="offline-tiny", seed=0)
+   result = dimension_pipeline.run(dimension_model, artifacts, model_id="offline-tiny", seed=0)
 
 The result publishes the real cache at ``("activations", "cache")``, shaped
 samples at ``("activations", "samples")``, estimates at ``("metrics",

--- a/docs/source/notebooks/tutorials/chess-dimension-estimation.ipynb
+++ b/docs/source/notebooks/tutorials/chess-dimension-estimation.ipynb
@@ -7,6 +7,8 @@
       "source": [
         "# Chess Dimension Estimation\n",
         "\n",
+        "This is an extended chess visualisation. For the canonical declared workflow with a one-pass preflight plan and named TensorDict artifacts, start with [Declared Pipelines](../../declared-pipelines.html).\n",
+        "\n",
         "This tutorial estimates intrinsic dimension from chess-network activations channel by channel, then compares trends across backbone layers and head-adjacent features.\n",
         "\n",
         "The workflow builds on LCZeroLens usage patterns and references <cite data-cite=\"Yoann_Poupart_LCZeroLens\">LCZeroLens</cite>."

--- a/docs/source/notebooks/tutorials/chess-dimension-estimation.ipynb
+++ b/docs/source/notebooks/tutorials/chess-dimension-estimation.ipynb
@@ -7,7 +7,7 @@
       "source": [
         "# Chess Dimension Estimation\n",
         "\n",
-        "This is an extended chess visualisation. For the canonical declared workflow with a one-pass preflight plan and named TensorDict artifacts, start with [Declared Pipelines](../../declared-pipelines.html).\n",
+        "This is an extended chess visualisation. For the canonical declared workflow with a one-pass preflight plan and named TensorDict artifacts, start with the **Declared Pipelines (Offline)** tutorial.\n",
         "\n",
         "This tutorial estimates intrinsic dimension from chess-network activations channel by channel, then compares trends across backbone layers and head-adjacent features.\n",
         "\n",

--- a/docs/source/notebooks/tutorials/concept-attribution.ipynb
+++ b/docs/source/notebooks/tutorials/concept-attribution.ipynb
@@ -7,7 +7,7 @@
       "source": [
         "# Concept Attribution (LRP + RelMax)\n",
         "\n",
-        "This is an extended natural-image visualisation. For the canonical declared workflow with a two-pass preflight plan and named TensorDict artifacts, start with [Declared Pipelines](../../declared-pipelines.html).\n",
+        "This is an extended natural-image visualisation. For the canonical declared workflow with a two-pass preflight plan and named TensorDict artifacts, start with the **Declared Pipelines (Offline)** tutorial.\n",
         "\n",
         "This tutorial walks through a simple concept attribution pipeline with **VGG16**.\n",
         "\n",

--- a/docs/source/notebooks/tutorials/concept-attribution.ipynb
+++ b/docs/source/notebooks/tutorials/concept-attribution.ipynb
@@ -7,6 +7,8 @@
       "source": [
         "# Concept Attribution (LRP + RelMax)\n",
         "\n",
+        "This is an extended natural-image visualisation. For the canonical declared workflow with a two-pass preflight plan and named TensorDict artifacts, start with [Declared Pipelines](../../declared-pipelines.html).\n",
+        "\n",
         "This tutorial walks through a simple concept attribution pipeline with **VGG16**.\n",
         "\n",
         "We will:\n",

--- a/docs/source/notebooks/tutorials/declared-pipelines.ipynb
+++ b/docs/source/notebooks/tutorials/declared-pipelines.ipynb
@@ -1,0 +1,183 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "overview",
+   "metadata": {},
+   "source": [
+    "# Declared Pipelines (Offline)\n",
+    "\n",
+    "This canonical walkthrough runs entirely on a deterministic local model and tensors. It preflights each workflow before running it, then reads results only from declared TensorDict artifacts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "offline-model",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from torch import nn\n",
+    "from tensordict import TensorDict\n",
+    "\n",
+    "torch.manual_seed(0)\n",
+    "\n",
+    "\n",
+    "class TinyConceptModel(nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        self.linear1 = nn.Linear(10, 10)\n",
+    "        self.relu = nn.ReLU()\n",
+    "        self.linear2 = nn.Linear(10, 2)\n",
+    "\n",
+    "    def forward(self, input):\n",
+    "        return self.linear2(self.relu(self.linear1(input)))\n",
+    "\n",
+    "\n",
+    "class FeatureMap(nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        self.linear = nn.Linear(10, 12)\n",
+    "\n",
+    "    def forward(self, input):\n",
+    "        return self.linear(input).relu().reshape(-1, 3, 2, 2)\n",
+    "\n",
+    "\n",
+    "class TinyFeatureModel(nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        self.features = FeatureMap()\n",
+    "        self.head = nn.Linear(12, 2)\n",
+    "\n",
+    "    def forward(self, input):\n",
+    "        features = self.features(input)\n",
+    "        return self.head(features.flatten(1))\n",
+    "\n",
+    "\n",
+    "concept_model = TinyConceptModel().eval()\n",
+    "dimension_model = TinyFeatureModel().eval()\n",
+    "examples = torch.randn(6, 10)\n",
+    "labels = torch.tensor([1, 1, 1, 0, 0, 0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "concept-heading",
+   "metadata": {},
+   "source": [
+    "## Concept-conditioned attribution: two model passes\n",
+    "\n",
+    "The first LRP pass publishes concept-example relevance. `ConceptSelectionStage` turns it and the labels into a named selection artifact, and the conditioned LRP pass consumes that artifact. No callback or prepared-hook state crosses the boundary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "concept-plan",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tdhook.attribution import LRP\n",
+    "from tdhook.concepts import ChannelConditionedLRPStage, ConceptSelectionStage\n",
+    "from tdhook.pipeline import Pipeline\n",
+    "from tdhook.stages import AttributionStage\n",
+    "\n",
+    "concept_pipeline = Pipeline(\n",
+    "    [\n",
+    "        AttributionStage(\n",
+    "            \"concept-relevances\",\n",
+    "            LRP(input_modules=[\"linear1\"], warn_on_missing_rule=False),\n",
+    "            attribution_key=(\"attributions\", \"concept_examples\"),\n",
+    "            legacy_attribution_key=(\"attr\", \"linear1\"),\n",
+    "        ),\n",
+    "        ConceptSelectionStage(\"select-concept\"),\n",
+    "        ChannelConditionedLRPStage(\n",
+    "            \"conditioned-relevance\", LRP(warn_on_missing_rule=False), condition_module=\"linear1\"\n",
+    "        ),\n",
+    "    ]\n",
+    ")\n",
+    "concept_artifacts = TensorDict({\"inputs\": {\"input\": examples, \"concept_labels\": labels}}, batch_size=[len(examples)])\n",
+    "concept_plan = concept_pipeline.plan(concept_artifacts)\n",
+    "assert concept_plan.model_passes == 2\n",
+    "[(run.stages, run.model_passes, run.coalesced) for run in concept_plan.runs]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "concept-run",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "concept_result = concept_pipeline.run(concept_model, concept_artifacts, model_id=\"offline-tiny\", seed=0)\n",
+    "selection = concept_result.artifacts[(\"metrics\", \"concept_selection\")]\n",
+    "conditioned = concept_result.artifacts[(\"attributions\", \"conditioned\")]\n",
+    "print(\"selected channel:\", selection[\"channel\"][0].item())\n",
+    "print(\"conditioned relevance shape:\", tuple(conditioned.shape))\n",
+    "[(record.stage, record.method, record.parents) for record in concept_result.provenance]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dimension-heading",
+   "metadata": {},
+   "source": [
+    "## Conditioned intrinsic dimension: one model pass\n",
+    "\n",
+    "Only activation capture runs the model. Channel selection, TwoNN estimation, and summary are artifact-only stages. Plotting or domain rendering belongs downstream of these stable artifacts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dimension-plan",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tdhook.dimension import channel_conditioned_samples, conditioned_dimension_pipeline\n",
+    "from tdhook.latent import ActivationCaching\n",
+    "from tdhook.latent.dimension_estimation import TwoNnDimensionEstimator\n",
+    "\n",
+    "dimension_pipeline = conditioned_dimension_pipeline(\n",
+    "    ActivationCaching(\"features\"),\n",
+    "    \"features\",\n",
+    "    channel_conditioned_samples,\n",
+    "    TwoNnDimensionEstimator(),\n",
+    ")\n",
+    "dimension_artifacts = TensorDict({\"inputs\": {\"input\": examples}}, batch_size=[len(examples)])\n",
+    "dimension_plan = dimension_pipeline.plan(dimension_artifacts)\n",
+    "assert dimension_plan.model_passes == 1\n",
+    "[(run.stages, run.model_passes, run.coalesced) for run in dimension_plan.runs]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dimension-run",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dimension_result = dimension_pipeline.run(dimension_model, dimension_artifacts, model_id=\"offline-tiny\", seed=0)\n",
+    "samples = dimension_result.artifacts[(\"activations\", \"samples\")].data\n",
+    "dimensions = dimension_result.artifacts[(\"metrics\", \"dimension\")].data\n",
+    "summary = dimension_result.artifacts[(\"metrics\", \"dimension_summary\")].data\n",
+    "print(\"samples:\", tuple(samples.shape), \"dimensions:\", tuple(dimensions.shape))\n",
+    "summary"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -40,7 +40,10 @@ Most methods should work with minimal configuration. Here's a basic example of r
         }).unsqueeze(0)
         td = hooked_model(td)  # Access attribution with td.get(("attr", "input"))
 
-For more detailed examples, see the :doc:`methods` page.
+For a small, fully offline declared-workflow example, start with
+:doc:`declared-pipelines`.  It shows preflight planning, exact model-pass
+budgets, named TensorDict artifacts, provenance, and conservative stage
+splits.  For individual methods, see the :doc:`methods` page.
 
 Composition terminology
 -----------------------

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -3,8 +3,8 @@ Tutorials
 
 Tutorials may demonstrate a method on a **composed model**, a **same-run hook
 composition**, or a **multi-stage pipeline**.  These terms follow the
-:doc:`composition` contract.  Existing notebook hand-offs are migration
-candidates for named TensorDict artifacts and declared pipeline stages.
+:doc:`composition` contract.  Canonical declared workflows exchange named
+TensorDict artifacts and show their preflight model-pass budget before running.
 
 .. raw:: html
 
@@ -24,6 +24,23 @@ candidates for named TensorDict artifacts and declared pipeline stages.
 
 .. grid:: 2
    :gutter: 3
+
+   .. grid-item-card::
+      :link: declared-pipelines
+      :class-card: surface
+      :class-body: surface
+
+      .. raw:: html
+
+         <div class="d-flex align-items-center">
+            <div class="d-flex justify-content-center" style="min-width: 50px; margin-right: 20px; height: 100%;">
+               <i class="fa-solid fa-diagram-project fa-2x"></i>
+            </div>
+            <div>
+               <h5 class="card-title">Declared Pipelines (Offline)</h5>
+               <p class="card-text">Plan and run deterministic concept-attribution and conditioned-dimension workflows with named artifacts.</p>
+            </div>
+         </div>
 
    .. grid-item-card::
       :link: notebooks/tutorials/torchrl-ppo.ipynb
@@ -71,8 +88,8 @@ candidates for named TensorDict artifacts and declared pipeline stages.
                <i class="fa-solid fa-map fa-2x"></i>
             </div>
             <div>
-               <h5 class="card-title">Concept Attribution (LRP + RelMax)</h5>
-               <p class="card-text">Build a striped concept and visualize concept-conditioned relevance on natural images.</p>
+               <h5 class="card-title">Concept Attribution Visualisation (Extended)</h5>
+               <p class="card-text">Optional natural-image visualisation that builds on the declared concept-attribution workflow.</p>
             </div>
          </div>
 
@@ -88,8 +105,8 @@ candidates for named TensorDict artifacts and declared pipeline stages.
                <i class="fa-solid fa-chess-board fa-2x"></i>
             </div>
             <div>
-               <h5 class="card-title">Chess Dimension Estimation</h5>
-               <p class="card-text">Estimate channel-wise intrinsic dimension from chess activations and compare layers, heads, and opening splits.</p>
+               <h5 class="card-title">Chess Dimension Visualisation (Extended)</h5>
+               <p class="card-text">Optional chess rendering and plots downstream of declared conditioned-dimension artifacts.</p>
             </div>
          </div>
 
@@ -98,6 +115,8 @@ candidates for named TensorDict artifacts and declared pipeline stages.
    :maxdepth: 2
 
    notebooks/tutorials/torchrl-ppo.ipynb
+   declared-pipelines
+   notebooks/tutorials/declared-pipelines.ipynb
    notebooks/tutorials/chess-value-saliency.ipynb
    notebooks/tutorials/concept-attribution.ipynb
    notebooks/tutorials/chess-dimension-estimation.ipynb


### PR DESCRIPTION
## Summary

- add an offline declared-pipeline walkthrough and executable notebook
- make the documented canonical path expose concept attribution's two passes and conditioned dimension's one pass
- clarify artifact/provenance hand-offs, conservative split behavior, and how the 25+ methods inventory should be read
- mark the existing natural-image and chess notebooks as extended visualisation paths

Closes #63

## Validation

- `just tests` (500 passed, 1 skipped)
- `just docs` (HTML and llms.txt build succeeded without warnings)
- executed `declared-pipelines.ipynb` with nbconvert
